### PR TITLE
Split habitual sin markdown and progress fix

### DIFF
--- a/__tests__/habitual-sin/progress-api.test.js
+++ b/__tests__/habitual-sin/progress-api.test.js
@@ -34,7 +34,7 @@ const mockUser = {
 const mockReadingProgress = {
   id: 1,
   user_id: 1,
-  chapter_slug: 'test-chapter',
+  chapter_slug: 'test-chapter-a',
   reading_started_at: new Date(),
   last_read_at: new Date(),
   progress_percentage: 75,
@@ -51,7 +51,7 @@ const mockReadingProgress = {
 const mockUserNote = {
   id: 1,
   user_id: 1,
-  chapter_slug: 'test-chapter',
+  chapter_slug: 'test-chapter-a',
   note_title: 'Test Reflection',
   note_content: 'This is a test reflection on the chapter content.',
   note_type: 'reflection',
@@ -96,7 +96,7 @@ describe('/api/learn/progress', () => {
   describe('GET /api/learn/progress', () => {
     test('should return progress for authenticated user', async () => {
       const token = createJwtToken();
-      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter' }, {
+      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter-a' }, {
         authorization: `Bearer ${token}`
       });
 
@@ -106,12 +106,12 @@ describe('/api/learn/progress', () => {
 
       expect(mockDb.select).toHaveBeenCalled();
       expect(mockDb.where).toHaveBeenCalledWith('user_id', mockUser.id);
-      expect(mockDb.where).toHaveBeenCalledWith('chapter_slug', 'test-chapter');
+      expect(mockDb.where).toHaveBeenCalledWith('chapter_slug', 'test-chapter-a');
       expect(res.json).toHaveBeenCalledWith(mockReadingProgress);
     });
 
     test('should return 401 for unauthenticated request', async () => {
-      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter' });
+      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter-a' });
 
       await progressHandler(req, res);
 
@@ -134,7 +134,7 @@ describe('/api/learn/progress', () => {
 
     test('should handle database errors gracefully', async () => {
       const token = createJwtToken();
-      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter' }, {
+      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter-a' }, {
         authorization: `Bearer ${token}`
       });
 
@@ -193,7 +193,7 @@ describe('/api/learn/progress', () => {
     test('should validate progress percentage range', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('POST', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         reading: {
           progressPercentage: 150 // Invalid - over 100
         }
@@ -222,7 +222,7 @@ describe('/api/learn/progress', () => {
     test('should update existing progress record', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('PUT', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         ...updateData
       }, {}, {
         authorization: `Bearer ${token}`
@@ -269,7 +269,7 @@ describe('/api/learn/progress', () => {
     test('should update quiz progress', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('PUT', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         ...quizData
       }, {}, {
         authorization: `Bearer ${token}`
@@ -290,7 +290,7 @@ describe('/api/learn/progress', () => {
     test('should validate quiz score range', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('PUT', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         quiz: {
           score: 150 // Invalid - over 100
         }
@@ -316,7 +316,7 @@ describe('/api/learn/notes', () => {
   describe('GET /api/learn/notes', () => {
     test('should return notes for authenticated user', async () => {
       const token = createJwtToken();
-      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter' }, {
+      const { req, res } = createMockReqRes('GET', {}, { chapterSlug: 'test-chapter-a' }, {
         authorization: `Bearer ${token}`
       });
 
@@ -347,7 +347,7 @@ describe('/api/learn/notes', () => {
 
   describe('POST /api/learn/notes', () => {
     const noteData = {
-      chapterSlug: 'test-chapter',
+      chapterSlug: 'test-chapter-a',
       title: 'New Reflection',
       content: 'This is my reflection on the chapter.',
       tags: ['reflection', 'growth'],
@@ -367,7 +367,7 @@ describe('/api/learn/notes', () => {
 
       expect(mockDb.insert).toHaveBeenCalledWith(expect.objectContaining({
         user_id: mockUser.id,
-        chapter_slug: 'test-chapter',
+        chapter_slug: 'test-chapter-a',
         note_title: 'New Reflection',
         note_content: 'This is my reflection on the chapter.',
         tags: JSON.stringify(['reflection', 'growth'])
@@ -379,7 +379,7 @@ describe('/api/learn/notes', () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('POST', {
         // Missing title and content
-        chapterSlug: 'test-chapter'
+        chapterSlug: 'test-chapter-a'
       }, {}, {
         authorization: `Bearer ${token}`
       });
@@ -395,7 +395,7 @@ describe('/api/learn/notes', () => {
     test('should validate content length', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('POST', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         title: 'Test',
         content: 'x'.repeat(10001) // Too long
       }, {}, {
@@ -525,7 +525,7 @@ describe('/api/learn/notes', () => {
     test('should sanitize user input', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('POST', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         title: '<script>alert("xss")</script>Safe Title',
         content: 'Safe content with <b>allowed</b> HTML',
         tags: ['<script>', 'safe-tag']
@@ -547,7 +547,7 @@ describe('/api/learn/notes', () => {
     test('should validate tag format', async () => {
       const token = createJwtToken();
       const { req, res } = createMockReqRes('POST', {
-        chapterSlug: 'test-chapter',
+        chapterSlug: 'test-chapter-a',
         title: 'Test',
         content: 'Test content',
         tags: 'not-an-array' // Should be array

--- a/hooks/useProgress.tsx
+++ b/hooks/useProgress.tsx
@@ -314,14 +314,13 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
   };
 
   // Calculate overall progress
-  const getOverallProgress = () => {
-    const allChapters = Object.keys(progress);
-    const completedChapters = allChapters.filter(slug => progress[slug]?.completed_at);
-    
+  const getOverallProgress = (totalChapters?: number) => {
+    const completed = Object.values(progress).filter(p => p?.completed_at).length;
+    const total = typeof totalChapters === 'number' ? totalChapters : Object.keys(progress).length;
     return {
-      completed: completedChapters.length,
-      total: allChapters.length,
-      percentage: allChapters.length > 0 ? (completedChapters.length / allChapters.length) * 100 : 0,
+      completed,
+      total,
+      percentage: total > 0 ? (completed / total) * 100 : 0,
     };
   };
 

--- a/pages/learn/habitual-sin/index.tsx
+++ b/pages/learn/habitual-sin/index.tsx
@@ -74,7 +74,7 @@ export default function HabitualSinIndexPage({ bookData }: Props) {
   }, []);
 
   // Calculate progress statistics
-  const overallProgress = getOverallProgress();
+  const overallProgress = getOverallProgress(bookData.chapters.length);
   const totalReadingTime = bookData.chapters.reduce((sum, chapter) => sum + chapter.estimatedReadingTime, 0);
   
   // Get chapter progress details

--- a/scripts/split-habitual-sin.js
+++ b/scripts/split-habitual-sin.js
@@ -1,0 +1,140 @@
+const fs = require('fs');
+const path = require('path');
+const { extractBibleVerses, generateSlug } = require('./convert-habitual-sin');
+
+const INPUT_FILE = path.join(__dirname, '..', 'content', 'habitual-sin', '2025-05-11 The Eternal Danger of Habitual Sin.md');
+const OUTPUT_DIR = path.join(__dirname, '..', 'content', 'habitual-sin');
+
+function alphaIndex(num) {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  let result = '';
+  do {
+    result = letters[num % 26] + result;
+    num = Math.floor(num / 26) - 1;
+  } while (num >= 0);
+  return result;
+}
+
+function pad(num) {
+  return String(num).padStart(2, '0');
+}
+
+function createFrontmatter(section) {
+  const fm = {
+    title: section.title,
+    order: section.order,
+    slug: section.slug,
+    chapterNumber: section.chapterNumber || null,
+    keyVerses: section.keyVerses,
+    audioUrl: null,
+    estimatedReadingTime: Math.ceil(section.content.split(/\s+/).length / 200)
+  };
+  const lines = ['---'];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      v.forEach(val => lines.push(`  - "${val}"`));
+    } else {
+      lines.push(`${k}: ${v === null ? 'null' : `"${v}"`}`);
+    }
+  }
+  lines.push('---', '');
+  return lines.join('\n');
+}
+
+function parse() {
+  if (!fs.existsSync(INPUT_FILE)) {
+    console.error('Input file not found:', INPUT_FILE);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(INPUT_FILE, 'utf8');
+  const lines = raw.split(/\r?\n/);
+
+  const sections = [];
+  let current = null;
+  let order = 0;
+  let chapterIndex = -1;
+  let subIndex = 0;
+
+  for (const line of lines) {
+    const match = line.match(/^(#{1,3})\s+(.*\S.*)$/);
+    if (match) {
+      let level = match[1].length;
+      let title = match[2].replace(/<[^>]+>/g, '').trim();
+      if (title.toLowerCase() === 'table of contents') continue;
+      if (title === '') continue;
+
+      if (current) {
+        current.content = current.content.join('\n').trim();
+        current.keyVerses = extractBibleVerses(current.content);
+        sections.push(current);
+      }
+
+      let chapterNumber = null;
+      const chapterMatch = title.match(/^Chapter\s+(\d+\w?)[:\s-]*(.*)$/i);
+      if (chapterMatch) {
+        chapterNumber = chapterMatch[1];
+        title = chapterMatch[2] || `Chapter ${chapterNumber}`;
+      }
+
+      if (level === 1) {
+        chapterIndex += 1;
+        subIndex = 0;
+      } else {
+        subIndex += 1;
+      }
+      const prefix = level === 1 ? pad(chapterIndex) : pad(chapterIndex) + alphaIndex(subIndex - 1);
+      const slug = generateSlug(title);
+      current = {
+        numbering: prefix,
+        title,
+        slug,
+        order: order++,
+        chapterNumber,
+        level,
+        content: []
+      };
+      continue;
+    }
+
+    if (current) {
+      current.content.push(line);
+    }
+  }
+
+  if (current) {
+    current.content = current.content.join('\n').trim();
+    current.keyVerses = extractBibleVerses(current.content);
+    sections.push(current);
+  }
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  const index = { title: 'The Eternal Danger of Habitual Sin', chapters: [] };
+
+  sections.forEach(sec => {
+    const frontmatter = createFrontmatter(sec);
+    const filepath = path.join(OUTPUT_DIR, `${sec.numbering}-${sec.slug}.mdx`);
+    fs.writeFileSync(filepath, frontmatter + sec.content);
+    index.chapters.push({
+      title: sec.title,
+      slug: sec.slug,
+      order: sec.order,
+      chapterNumber: sec.chapterNumber,
+      keyVerses: sec.keyVerses,
+      estimatedReadingTime: Math.ceil(sec.content.split(/\s+/).length / 200)
+    });
+    console.log('Created', filepath);
+  });
+
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'index.json'), JSON.stringify(index, null, 2));
+  console.log('Index updated with', index.chapters.length, 'entries');
+}
+
+if (require.main === module) {
+  parse();
+}
+
+module.exports = { parse };


### PR DESCRIPTION
## Summary
- add script `split-habitual-sin.js` to generate numbered MDX files from the source markdown file
- tweak progress hook to accept optional total chapter count
- use new progress calculation in habitual-sin overview page
- update progress API tests to use subchapter slug

## Testing
- `npm test` *(fails: Jest encountered unexpected token and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_683f4435f5988320a39b831d217170d9