### PR TITLE
Add PDF upload feature

### DIFF
--- a/Reference/pdfs_table_reference.md
+++ b/Reference/pdfs_table_reference.md
@@ -1,0 +1,21 @@
+# PDFs Table
+
+## Purpose
+Stores metadata for uploaded PDF documents containing scriptural or thematic content.
+
+## Columns and Types
+
+| Column Name | Type | Constraints | Default | Description |
+|-------------|------|-------------|---------|-------------|
+| id | integer | PRIMARY KEY, AUTO INCREMENT | | Unique identifier for the PDF |
+| title | string(255) | NOT NULL | | Title of the document |
+| author | string(255) | | | Author or source of the document |
+| pdf_url | string(255) | NOT NULL | | S3 key/URL of the uploaded PDF |
+| ai_assisted | boolean | | false | Indicates if AI assisted in creation |
+| themes | text[] | | | Array of themes/tags associated with the PDF |
+| uploaded_by | integer | FOREIGN KEY (users.id) | | ID of the user who uploaded |
+| created_at | timestamp with time zone | | CURRENT_TIMESTAMP | Timestamp of when the PDF was uploaded |
+
+## Relationships
+
+- `uploaded_by` references the `id` column in the `users` table.

--- a/components/UploadPage/PdfUploadProgressBar.tsx
+++ b/components/UploadPage/PdfUploadProgressBar.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useFormContext } from 'react-hook-form';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  onProgressChange: (progress: number) => void;
+}
+
+const steps = [
+  { name: 'Info', fields: ['title', 'themes', 'pdf_url'] },
+];
+
+const PdfUploadProgressBar: React.FC<Props> = ({ onProgressChange }) => {
+  const { watch } = useFormContext();
+  const watchedFields = watch();
+  const prevRef = useRef(0);
+
+  const progress = useMemo(() => {
+    let total = 0;
+    let filled = 0;
+
+    steps.forEach(step => {
+      step.fields.forEach(field => {
+        total++;
+        if (Array.isArray(watchedFields[field])) {
+          if (watchedFields[field].length > 0) filled++; 
+        } else if (watchedFields[field]) {
+          filled++; 
+        }
+      });
+    });
+
+    return Math.round((filled / total) * 100);
+  }, [watchedFields]);
+
+  useEffect(() => {
+    if (progress !== prevRef.current) {
+      onProgressChange(progress);
+      prevRef.current = progress;
+    }
+  }, [progress, onProgressChange]);
+
+  return (
+    <div className="w-full space-y-2">
+      <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+        <span>Upload Progress</span>
+        <span>{progress}% Complete</span>
+      </div>
+      <ProgressPrimitive.Root className="relative h-4 w-full overflow-hidden rounded-full bg-secondary">
+        <ProgressPrimitive.Indicator
+          className={cn('h-full w-full flex-1 transition-all duration-500 ease-in-out',
+            progress === 100 ? 'bg-gradient-to-r from-purple-500 to-pink-500' : 'bg-primary')}
+          style={{ transform: `translateX(-${100 - progress}%)` }}
+        />
+      </ProgressPrimitive.Root>
+    </div>
+  );
+};
+
+export default PdfUploadProgressBar;

--- a/db/migrations/20241017090000_create_pdfs_table.js
+++ b/db/migrations/20241017090000_create_pdfs_table.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('pdfs', function(table) {
+    table.increments('id').primary();
+    table.string('title', 255).notNullable();
+    table.string('author', 255);
+    table.string('pdf_url', 255).notNullable();
+    table.boolean('ai_assisted').defaultTo(false);
+    table.specificType('themes', 'text[]');
+    table.integer('uploaded_by').unsigned();
+    table.foreign('uploaded_by').references('id').inTable('users').onDelete('SET NULL');
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('pdfs');
+};

--- a/pages/api/pdfs/upload.ts
+++ b/pages/api/pdfs/upload.ts
@@ -1,0 +1,34 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import db from '@/db';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { title, author, ai_assisted, themes, pdf_url, uploaded_by } = req.body;
+
+  if (!title || !pdf_url || !uploaded_by || !Array.isArray(themes) || themes.length === 0) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  try {
+    const [inserted] = await db('pdfs')
+      .insert({
+        title,
+        author: author || null,
+        pdf_url,
+        ai_assisted: ai_assisted || false,
+        themes,
+        uploaded_by,
+        created_at: new Date()
+      })
+      .returning('id');
+
+    res.status(200).json({ id: inserted.id });
+  } catch (error) {
+    console.error('Error saving PDF:', error);
+    res.status(500).json({ message: 'Error saving PDF' });
+  }
+}

--- a/pages/pdfs/upload.tsx
+++ b/pages/pdfs/upload.tsx
@@ -1,0 +1,285 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import axios from 'axios';
+import { toast } from 'sonner';
+
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import PdfUploadProgressBar from '@/components/UploadPage/PdfUploadProgressBar';
+import { Check, ChevronsUpDown, X } from 'lucide-react';
+import { THEMES } from '@/lib/constants';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+
+const MAX_PDF_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+const formSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  author: z.string().optional(),
+  ai_assisted: z.boolean().default(false),
+  themes: z.array(z.string()).min(1, 'Select at least one theme'),
+  pdf_url: z.string().min(1, 'PDF upload required'),
+});
+
+type FormValues = z.infer<typeof formSchema> & { pdf_file?: File | null };
+
+export default function UploadPdf() {
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: '',
+      author: '',
+      ai_assisted: false,
+      themes: [],
+      pdf_url: '',
+    },
+  });
+
+  const [themeSearch, setThemeSearch] = useState('');
+  const [openTheme, setOpenTheme] = useState(false);
+  const selectedThemes = form.watch('themes') as string[];
+
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [uploadStatus, setUploadStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!user) {
+    return null;
+  }
+
+  const filteredThemes = THEMES.filter(theme =>
+    theme.toLowerCase().includes(themeSearch.toLowerCase())
+  );
+
+  const handleThemeToggle = (theme: string) => {
+    let updated: string[];
+    if (selectedThemes.includes(theme)) {
+      updated = selectedThemes.filter(t => t !== theme);
+    } else {
+      updated = [...selectedThemes, theme];
+    }
+    form.setValue('themes', updated, { shouldValidate: true });
+  };
+
+  const clearThemes = () => {
+    form.setValue('themes', [], { shouldValidate: true });
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.type !== 'application/pdf') {
+      toast.error('Only PDF files are allowed');
+      return;
+    }
+
+    if (file.size > MAX_PDF_FILE_SIZE) {
+      toast.error('PDF must be 10MB or smaller');
+      return;
+    }
+
+    try {
+      setUploadStatus('uploading');
+      const { data } = await axios.post('/api/upload-url', {
+        fileType: file.type,
+        fileExtension: 'pdf',
+        title: form.getValues('title') || file.name.replace(/\.pdf$/i, ''),
+        userId: user.id,
+        fileSize: file.size,
+        uploadType: 'pdf',
+      });
+
+      await axios.put(data.signedUrl, file, {
+        headers: { 'Content-Type': file.type },
+        onUploadProgress: (progressEvent) => {
+          const progress = Math.round((progressEvent.loaded * 100) / (progressEvent.total || 1));
+          setUploadProgress(progress);
+        },
+      });
+
+      form.setValue('pdf_url', data.fileKey, { shouldValidate: true });
+      setUploadStatus('success');
+      toast.success('PDF uploaded');
+    } catch (err: any) {
+      console.error('Upload failed:', err);
+      setUploadStatus('error');
+      toast.error('Upload failed');
+    }
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    if (!user) {
+      toast.error('Please log in');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await axios.post('/api/pdfs/upload', {
+        ...values,
+        uploaded_by: user.id,
+      });
+      if (response.status === 200 && response.data.id) {
+        toast.success('PDF saved');
+        router.push(`/pdfs/${response.data.id}`);
+      } else {
+        toast.error('Upload failed');
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('Upload failed');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Upload PDF</title>
+      </Head>
+      <div className="container mx-auto max-w-2xl py-8">
+        <h1 className="text-2xl font-bold mb-4">Upload PDF</h1>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <PdfUploadProgressBar onProgressChange={() => {}} />
+
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <Input placeholder="Document title" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="author"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Author</FormLabel>
+                <FormControl>
+                  <Input placeholder="Optional" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="ai_assisted"
+            render={({ field }) => (
+              <FormItem className="flex items-center space-x-2">
+                <FormLabel>AI Assistance</FormLabel>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="themes"
+            render={() => (
+              <FormItem className="flex flex-col">
+                <FormLabel>Themes/Tags</FormLabel>
+                <Popover open={openTheme} onOpenChange={setOpenTheme}>
+                  <PopoverTrigger asChild>
+                    <FormControl>
+                      <Button variant="outline" role="combobox" aria-expanded={openTheme} className="w-full justify-between">
+                        {selectedThemes.length > 0 ? `${selectedThemes.length} selected` : 'Select themes...'}
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </FormControl>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-full p-0">
+                    <div className="p-2">
+                      <div className="flex items-center justify-between pb-2">
+                        <Input placeholder="Search themes..." value={themeSearch} onChange={(e) => setThemeSearch(e.target.value)} className="mr-2" />
+                        <Button variant="outline" size="sm" onClick={clearThemes}>Clear</Button>
+                      </div>
+                      <div className="max-h-[200px] overflow-y-auto">
+                        {filteredThemes.map(theme => (
+                          <div
+                            key={theme}
+                            className={cn('flex cursor-pointer items-center rounded-md px-2 py-1 hover:bg-accent',
+                              selectedThemes.includes(theme) && 'bg-accent')}
+                            onClick={() => handleThemeToggle(theme)}
+                          >
+                            <div className="mr-2 h-4 w-4 border border-primary rounded flex items-center justify-center">
+                              {selectedThemes.includes(theme) && <Check className="h-3 w-3" />}
+                            </div>
+                            {theme}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {selectedThemes.map(theme => (
+                    <div key={theme} className="bg-secondary text-secondary-foreground rounded-full px-2 py-1 text-sm flex items-center">
+                      {theme}
+                      <Button variant="ghost" size="sm" className="ml-1 h-4 w-4 p-0" onClick={() => handleThemeToggle(theme)}>
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                  {selectedThemes.length > 0 && (
+                    <Button variant="outline" size="sm" onClick={clearThemes} className="mt-1">Clear All</Button>
+                  )}
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="pdf_url"
+            render={() => (
+              <FormItem>
+                <FormLabel>PDF File</FormLabel>
+                <FormControl>
+                  <Input type="file" accept="application/pdf" onChange={handleFileChange} />
+                </FormControl>
+                {uploadStatus !== 'idle' && (
+                  <div className="mt-2">
+                    <PdfUploadProgressBar onProgressChange={setUploadProgress} />
+                    <p className="text-sm mt-1">
+                      {uploadStatus === 'uploading' && `Uploading: ${uploadProgress}%`}
+                      {uploadStatus === 'success' && 'Upload successful!'}
+                      {uploadStatus === 'error' && 'Upload failed. Please try again.'}
+                    </p>
+                  </div>
+                )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Submitting...' : 'Submit'}
+          </Button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create migration and docs for `pdfs` table
- add API route to store PDF metadata
- add progress bar component for PDF uploads
- implement `/pdfs/upload` page to upload PDF files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff41453c08320bb34e8f8cd1b8cca