### PR TITLE
Add PDF support tables

### DIFF
--- a/Reference/bible_verses_table_reference.md
+++ b/Reference/bible_verses_table_reference.md
@@ -24,6 +24,10 @@ This table stores individual Bible verses and maintains relationships with songs
 | creative_inspiration_song_ids | integer[] | | '{}' | Array of song IDs creatively inspired by this verse |
 | genre_song_ids | jsonb | | '{}' | JSON object mapping genres to arrays of song IDs |
 | translation_song_ids | jsonb | | '{}' | JSON object mapping translations to arrays of song IDs |
+| all_pdf_ids | integer[] | | '{}' | Array of PDF IDs referencing this verse |
+| ai_content_pdf_ids | integer[] | | '{}' | PDF IDs with AI-assisted content |
+| human_content_pdf_ids | integer[] | | '{}' | PDF IDs with human-authored content |
+| theme_pdf_ids | jsonb | | '{}' | JSON object mapping themes to arrays of PDF IDs |
 
 ## Constraints
 
@@ -49,10 +53,14 @@ This table stores individual Bible verses and maintains relationships with songs
 | bible_verses_creative_inspiration_idx | creative_inspiration_song_ids | GIN |
 | bible_verses_genre_idx | genre_song_ids | GIN |
 | bible_verses_translation_idx | translation_song_ids | GIN |
+| bible_verses_all_pdfs_idx | all_pdf_ids | GIN |
+| bible_verses_ai_content_pdfs_idx | ai_content_pdf_ids | GIN |
+| bible_verses_human_content_pdfs_idx | human_content_pdf_ids | GIN |
+| bible_verses_theme_pdfs_idx | theme_pdf_ids | GIN |
 
 ## Notes
 
-- The table uses array columns to efficiently store relationships between verses and songs.
+- The table uses array columns to efficiently store relationships between verses, songs, and PDFs.
 - GIN indexes are used for efficient querying of array and JSON columns.
 - The `genre_song_ids` and `translation_song_ids` columns use JSONB type for flexible storage of genre and translation data.
 - Consider adding a B-tree index on (`book`, `chapter`, `verse`) for faster lookups.

--- a/Reference/pdf_comments_table_reference.md
+++ b/Reference/pdf_comments_table_reference.md
@@ -1,0 +1,32 @@
+# PDF Comments Table
+
+## Purpose
+Stores public comments on PDFs, allowing for discussion and feedback. Supports nested replies.
+
+## Columns and Types
+
+| Column Name | Type | Constraints | Default | Description |
+|-------------|------|-------------|---------|-------------|
+| id | integer | PRIMARY KEY, AUTO INCREMENT | | Unique identifier for the comment |
+| pdf_id | integer | NOT NULL, FOREIGN KEY | | ID of the PDF being commented on |
+| user_id | integer | NOT NULL, FOREIGN KEY | | ID of the user who made the comment |
+| comment | text | NOT NULL | | The content of the comment |
+| page_number | integer | | NULL | Page of the PDF the comment refers to |
+| created_at | timestamp with time zone | | CURRENT_TIMESTAMP | When the comment was created |
+| updated_at | timestamp with time zone | | CURRENT_TIMESTAMP | When the comment was last updated |
+| parent_comment_id | integer | FOREIGN KEY | NULL | ID of the parent comment (for replies) |
+| is_pinned | boolean | | false | Whether the comment is pinned by a moderator |
+| is_approved | boolean | | true | Whether the comment is visible |
+| is_edited | boolean | | false | Whether the comment has been edited |
+
+## Relationships
+- `pdf_id` references `pdfs.id` with CASCADE on delete
+- `user_id` references `users.id` with CASCADE on delete
+- `parent_comment_id` references `pdf_comments.id` with SET NULL on delete
+
+## Indexes
+| Index Name | Columns | Type | Description |
+|------------|---------|------|-------------|
+| pdf_comments_pdf_id_idx | pdf_id | B-tree | Quickly fetch comments for a PDF |
+| pdf_comments_parent_comment_id_idx | parent_comment_id | B-tree | Retrieve replies for a comment |
+| pdf_comments_user_id_idx | user_id | B-tree | Lookup comments by user |

--- a/Reference/pdf_notes_table_reference.md
+++ b/Reference/pdf_notes_table_reference.md
@@ -1,0 +1,25 @@
+# PDF Notes Table
+
+## Purpose
+Stores private notes that users attach to PDFs for personal study.
+
+## Columns and Types
+
+| Column Name | Type | Constraints | Default | Description |
+|-------------|------|-------------|---------|-------------|
+| id | integer | PRIMARY KEY, AUTO INCREMENT | | Unique identifier for the note |
+| pdf_id | integer | NOT NULL, FOREIGN KEY | | ID of the PDF this note belongs to |
+| user_id | integer | NOT NULL, FOREIGN KEY | | Owner of the note |
+| note | text | NOT NULL | | Content of the note |
+| page_number | integer | | NULL | Page reference if applicable |
+| created_at | timestamp | | CURRENT_TIMESTAMP | When the note was created |
+| updated_at | timestamp | | CURRENT_TIMESTAMP | When the note was last updated |
+
+## Relationships
+- `pdf_id` references `pdfs.id` with CASCADE on delete
+- `user_id` references `users.id` with CASCADE on delete
+
+## Indexes
+| Index Name | Columns | Type | Description |
+|------------|---------|------|-------------|
+| pdf_notes_pdf_user_idx | (pdf_id, user_id) | B-tree | Quickly fetch a user's notes for a PDF |

--- a/Reference/pdf_ratings_table_reference.md
+++ b/Reference/pdf_ratings_table_reference.md
@@ -1,0 +1,23 @@
+# PDF Ratings Table
+
+## Purpose
+Stores user ratings for PDFs across multiple categories such as quality, theology, and helpfulness.
+
+## Columns and Types
+
+| Column Name | Type | Constraints | Default | Description |
+|-------------|------|-------------|---------|-------------|
+| id | integer | PRIMARY KEY, AUTO INCREMENT | | Unique identifier for the rating |
+| pdf_id | integer | NOT NULL, FOREIGN KEY | | ID of the rated PDF |
+| user_id | integer | NOT NULL, FOREIGN KEY | | ID of the user giving the rating |
+| quality | smallint | | 0 | Quality rating (-1, 0, 1) |
+| theology | smallint | | 0 | Theological soundness rating |
+| helpfulness | smallint | | 0 | Helpfulness rating |
+
+## Constraints
+- Unique constraint on (`pdf_id`, `user_id`) so each user rates a PDF only once
+
+## Relationships
+- `pdf_id` references `pdfs.id` with CASCADE on delete
+- `user_id` references `users.id` with CASCADE on delete
+

--- a/Reference/pdf_verses_table_reference.md
+++ b/Reference/pdf_verses_table_reference.md
@@ -1,0 +1,27 @@
+# PDF Verses Table
+
+## Purpose
+Establishes a many-to-many relationship between PDFs and Bible verses, similar to the `song_verses` table.
+
+## Columns and Types
+
+| Column Name | Type | Constraints | Description |
+|-------------|------|-------------|-------------|
+| pdf_id | integer | NOT NULL, FOREIGN KEY | ID of the PDF |
+| verse_id | integer | NOT NULL, FOREIGN KEY | ID of the Bible verse |
+
+## Primary Key
+Composite primary key on (`pdf_id`, `verse_id`).
+
+## Foreign Keys
+
+| Column | References | On Delete |
+|--------|------------|-----------|
+| pdf_id | pdfs(id) | CASCADE |
+| verse_id | bible_verses(id) | CASCADE |
+
+## Indexes
+The primary key columns are automatically indexed for efficient lookups.
+
+## Notes
+- Prevents duplicate PDF-to-verse mappings through the composite primary key.

--- a/Reference/pdfs_table_reference.md
+++ b/Reference/pdfs_table_reference.md
@@ -10,12 +10,21 @@ Stores metadata for uploaded PDF documents containing scriptural or thematic con
 | id | integer | PRIMARY KEY, AUTO INCREMENT | | Unique identifier for the PDF |
 | title | string(255) | NOT NULL | | Title of the document |
 | author | string(255) | | | Author or source of the document |
-| pdf_url | string(255) | NOT NULL | | S3 key/URL of the uploaded PDF |
-| ai_assisted | boolean | | false | Indicates if AI assisted in creation |
-| themes | text[] | | | Array of themes/tags associated with the PDF |
-| uploaded_by | integer | FOREIGN KEY (users.id) | | ID of the user who uploaded |
+| file_url | string(255) | NOT NULL | | Location of the PDF in S3 or CDN |
+| ai_assisted | boolean | NOT NULL | false | Indicates if AI assisted in creation |
+| themes | text[] | NOT NULL | '{}' | Array of themes/tags associated with the PDF |
+| uploaded_by | integer | NOT NULL, FOREIGN KEY (users.id) | | ID of the user who uploaded |
+| description | text | | | Optional description for the PDF |
+| is_public | boolean | NOT NULL | true | Whether the PDF is publicly visible |
 | created_at | timestamp with time zone | | CURRENT_TIMESTAMP | Timestamp of when the PDF was uploaded |
 
 ## Relationships
 
 - `uploaded_by` references the `id` column in the `users` table.
+
+## Indexes
+
+| Index Name | Columns | Type | Description |
+|------------|---------|------|-------------|
+| pdfs_uploaded_by_idx | uploaded_by | B-tree | For efficient queries on a user's uploads |
+| pdfs_created_at_idx | created_at | B-tree | For sorting or filtering by creation time |

--- a/db/migrations/20241017090000_create_pdfs_table.js
+++ b/db/migrations/20241017090000_create_pdfs_table.js
@@ -1,17 +1,140 @@
-exports.up = function(knex) {
-  return knex.schema.createTable('pdfs', function(table) {
+exports.up = async function(knex) {
+  await knex.schema.createTable('pdfs', function(table) {
     table.increments('id').primary();
     table.string('title', 255).notNullable();
     table.string('author', 255);
-    table.string('pdf_url', 255).notNullable();
-    table.boolean('ai_assisted').defaultTo(false);
-    table.specificType('themes', 'text[]');
-    table.integer('uploaded_by').unsigned();
-    table.foreign('uploaded_by').references('id').inTable('users').onDelete('SET NULL');
+    table.string('file_url', 255).notNullable();
+    table.integer('uploaded_by').unsigned().notNullable();
+    table
+      .foreign('uploaded_by')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.boolean('ai_assisted').notNullable().defaultTo(false);
+    table.specificType('themes', 'text[]').notNullable().defaultTo('{}');
+    table.text('description');
+    table.boolean('is_public').notNullable().defaultTo(true);
     table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.index('uploaded_by', 'pdfs_uploaded_by_idx');
+    table.index('created_at', 'pdfs_created_at_idx');
+  });
+
+  await knex.schema.createTable('pdf_verses', function(table) {
+    table.integer('pdf_id').unsigned().notNullable();
+    table.integer('verse_id').unsigned().notNullable();
+    table
+      .foreign('pdf_id')
+      .references('id')
+      .inTable('pdfs')
+      .onDelete('CASCADE');
+    table
+      .foreign('verse_id')
+      .references('id')
+      .inTable('bible_verses')
+      .onDelete('CASCADE');
+    table.primary(['pdf_id', 'verse_id']);
+  });
+
+  await knex.schema.createTable('pdf_comments', function(table) {
+    table.increments('id').primary();
+    table.integer('pdf_id').unsigned().notNullable();
+    table.integer('user_id').unsigned().notNullable();
+    table.text('comment').notNullable();
+    table.integer('page_number');
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.integer('parent_comment_id').unsigned();
+    table.boolean('is_pinned').defaultTo(false);
+    table.boolean('is_approved').defaultTo(true);
+    table.boolean('is_edited').defaultTo(false);
+    table
+      .foreign('pdf_id')
+      .references('id')
+      .inTable('pdfs')
+      .onDelete('CASCADE');
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table
+      .foreign('parent_comment_id')
+      .references('id')
+      .inTable('pdf_comments')
+      .onDelete('SET NULL');
+    table.index('pdf_id', 'pdf_comments_pdf_id_idx');
+    table.index('parent_comment_id', 'pdf_comments_parent_comment_id_idx');
+    table.index('user_id', 'pdf_comments_user_id_idx');
+  });
+
+  await knex.schema.createTable('pdf_notes', function(table) {
+    table.increments('id').primary();
+    table.integer('pdf_id').unsigned().notNullable();
+    table.integer('user_id').unsigned().notNullable();
+    table.text('note').notNullable();
+    table.integer('page_number');
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
+    table
+      .foreign('pdf_id')
+      .references('id')
+      .inTable('pdfs')
+      .onDelete('CASCADE');
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.index(['pdf_id', 'user_id'], 'pdf_notes_pdf_user_idx');
+  });
+
+  await knex.schema.createTable('pdf_ratings', function(table) {
+    table.increments('id').primary();
+    table.integer('pdf_id').unsigned().notNullable();
+    table.integer('user_id').unsigned().notNullable();
+    table.smallint('quality').defaultTo(0);
+    table.smallint('theology').defaultTo(0);
+    table.smallint('helpfulness').defaultTo(0);
+    table
+      .foreign('pdf_id')
+      .references('id')
+      .inTable('pdfs')
+      .onDelete('CASCADE');
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.unique(['pdf_id', 'user_id']);
+  });
+
+  await knex.schema.table('bible_verses', function(table) {
+    table.specificType('all_pdf_ids', 'integer[]').defaultTo('{}');
+    table.specificType('ai_content_pdf_ids', 'integer[]').defaultTo('{}');
+    table.specificType('human_content_pdf_ids', 'integer[]').defaultTo('{}');
+    table.jsonb('theme_pdf_ids').defaultTo('{}');
+    table.index('all_pdf_ids', 'bible_verses_all_pdfs_idx', 'GIN');
+    table.index('ai_content_pdf_ids', 'bible_verses_ai_content_pdfs_idx', 'GIN');
+    table.index('human_content_pdf_ids', 'bible_verses_human_content_pdfs_idx', 'GIN');
+    table.index('theme_pdf_ids', 'bible_verses_theme_pdfs_idx', 'GIN');
   });
 };
 
-exports.down = function(knex) {
-  return knex.schema.dropTable('pdfs');
+exports.down = async function(knex) {
+  await knex.schema.table('bible_verses', function(table) {
+    table.dropIndex('', 'bible_verses_all_pdfs_idx');
+    table.dropIndex('', 'bible_verses_ai_content_pdfs_idx');
+    table.dropIndex('', 'bible_verses_human_content_pdfs_idx');
+    table.dropIndex('', 'bible_verses_theme_pdfs_idx');
+    table.dropColumn('all_pdf_ids');
+    table.dropColumn('ai_content_pdf_ids');
+    table.dropColumn('human_content_pdf_ids');
+    table.dropColumn('theme_pdf_ids');
+  });
+
+  await knex.schema.dropTableIfExists('pdf_ratings');
+  await knex.schema.dropTableIfExists('pdf_notes');
+  await knex.schema.dropTableIfExists('pdf_comments');
+  await knex.schema.dropTableIfExists('pdf_verses');
+  await knex.schema.dropTableIfExists('pdfs');
 };

--- a/types.ts
+++ b/types.ts
@@ -94,3 +94,51 @@ export interface ForumCategory {
   description?: string;
   parent_category_id?: number;
 }
+
+export interface Pdf {
+  id: number;
+  title: string;
+  author?: string;
+  file_url: string;
+  uploaded_by: number;
+  ai_assisted: boolean;
+  themes: string[];
+  description?: string;
+  is_public: boolean;
+  created_at: string;
+}
+
+export interface PdfComment {
+  id: number;
+  pdf_id: number;
+  user_id: number;
+  username?: string;
+  comment: string;
+  page_number?: number;
+  parent_comment_id?: number;
+  created_at: string;
+  updated_at: string;
+  is_pinned: boolean;
+  is_approved: boolean;
+  is_edited: boolean;
+}
+
+export interface PdfNote {
+  id: number;
+  pdf_id: number;
+  user_id: number;
+  note: string;
+  page_number?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PdfRating {
+  id: number;
+  pdf_id: number;
+  user_id: number;
+  quality: number;
+  theology: number;
+  helpfulness: number;
+}
+


### PR DESCRIPTION
## Summary
- create pdfs table with details, join table, comments, notes, ratings
- link PDFs to bible verses and index pdf IDs on bible verses
- document new tables in Reference docs
- add TypeScript types for Pdf objects

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff96f09ec8320a1ab9e04d42e1126