### PR TITLE
Add PDF viewer page with comments and notes

### DIFF
--- a/components/PdfComments/CommentList.tsx
+++ b/components/PdfComments/CommentList.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { PdfComment } from '@/types';
+import { NewCommentForm } from './NewCommentForm';
+import { Button } from '@/components/ui/button';
+import ReactHtmlParser from 'html-react-parser';
+import { cn } from '@/lib/utils';
+
+interface CommentListProps {
+  comments: PdfComment[];
+  pdfId: number;
+  onCommentAdded: (comment: PdfComment) => void;
+}
+
+export const CommentList: React.FC<CommentListProps> = ({ comments, pdfId, onCommentAdded }) => {
+  const [replyingTo, setReplyingTo] = useState<number | null>(null);
+
+  const renderComments = (
+    commentList: PdfComment[],
+    parentId: number | null = null,
+    depth: number = 0
+  ) => {
+    return commentList
+      .filter((comment) => comment.parent_comment_id === parentId)
+      .map((comment) => (
+        <div
+          key={comment.id}
+          className={`p-4 bg-card rounded-lg shadow-sm ${depth > 0 ? 'ml-4 mt-2' : 'mt-4'}`}
+        >
+          <p className="text-sm text-muted-foreground mb-2">
+            {comment.username} • {new Date(comment.created_at).toLocaleString()}
+          </p>
+          <div className={richTextStyles.prose}>{ReactHtmlParser(comment.comment)}</div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setReplyingTo(replyingTo === comment.id ? null : comment.id)}
+            className="mt-2"
+          >
+            {replyingTo === comment.id ? 'Cancel Reply' : 'Reply'}
+          </Button>
+          {replyingTo === comment.id && (
+            <NewCommentForm
+              pdfId={pdfId}
+              onCommentAdded={(newComment) => {
+                onCommentAdded(newComment);
+                setReplyingTo(null);
+              }}
+              parentCommentId={comment.id}
+            />
+          )}
+          <div className="mt-2">{renderComments(commentList, comment.id, depth + 1)}</div>
+        </div>
+      ));
+  };
+
+  const richTextStyles = {
+    prose: cn(
+      'prose dark:prose-invert',
+      'prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-500',
+      'prose-ol:list-decimal prose-ul:list-disc',
+      'prose-h1:text-2xl prose-h1:font-bold prose-h1:mb-4',
+      'prose-h2:text-xl prose-h2:font-bold prose-h2:mb-3',
+      'prose-h3:text-lg prose-h3:font-bold prose-h3:mb-2',
+      'prose-ol:my-4 prose-ul:my-4',
+      'prose-ol:pl-4 prose-ul:pl-4'
+    ),
+  };
+
+  return <div className="space-y-4">{renderComments(comments)}</div>;
+};

--- a/components/PdfComments/NewCommentForm.tsx
+++ b/components/PdfComments/NewCommentForm.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import axios from 'axios';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import dynamic from 'next/dynamic';
+
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
+import 'react-quill/dist/quill.snow.css';
+
+interface NewCommentFormProps {
+  pdfId: number;
+  onCommentAdded: (comment: any) => void;
+  parentCommentId?: number;
+}
+
+export const NewCommentForm: React.FC<NewCommentFormProps> = ({ pdfId, onCommentAdded, parentCommentId }) => {
+  const { user } = useAuth();
+  const [content, setContent] = useState('');
+
+  const handleAddComment = async () => {
+    try {
+      const response = await axios.post(`/api/pdfs/${pdfId}/comments`, {
+        comment: content,
+        user_id: user?.id,
+        parent_comment_id: parentCommentId,
+      });
+      onCommentAdded(response.data);
+      setContent('');
+      toast.success('Comment added successfully!');
+    } catch (error) {
+      console.error('Error adding comment:', error);
+      toast.error('Failed to add comment');
+    }
+  };
+
+  return (
+    <div className="mb-6">
+      <div className="border rounded-md mb-2">
+        <ReactQuill
+          value={content}
+          onChange={setContent}
+          className="[&_.ql-editor]:min-h-[100px]"
+        />
+      </div>
+      <Button onClick={handleAddComment} disabled={!content}>
+        {parentCommentId ? 'Reply' : 'Add Comment'}
+      </Button>
+    </div>
+  );
+};

--- a/components/PdfNotes/NotesSection.tsx
+++ b/components/PdfNotes/NotesSection.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { PdfNote } from '@/types';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import axios from 'axios';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface NotesSectionProps {
+  initialNotes: PdfNote[];
+  pdfId: number;
+}
+
+export const NotesSection: React.FC<NotesSectionProps> = ({ initialNotes, pdfId }) => {
+  const { user } = useAuth();
+  const [notes, setNotes] = useState<PdfNote[]>(initialNotes);
+  const [note, setNote] = useState('');
+  const [page, setPage] = useState<number | ''>('');
+
+  const addNote = async () => {
+    if (!user || !note) return;
+    try {
+      const response = await axios.post(`/api/pdfs/${pdfId}/notes`, {
+        note,
+        page_number: page || null,
+      });
+      setNotes([response.data, ...notes]);
+      setNote('');
+      setPage('');
+    } catch (err) {
+      console.error('Error adding note:', err);
+    }
+  };
+
+  const deleteNote = async (id: number) => {
+    try {
+      await axios.delete(`/api/pdfs/${pdfId}/notes/${id}`);
+      setNotes(notes.filter(n => n.id !== id));
+    } catch (err) {
+      console.error('Error deleting note:', err);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {user ? (
+        <div className="space-y-2">
+          <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add a note" />
+          <Input
+            value={page}
+            onChange={(e) => setPage(e.target.value ? Number(e.target.value) : '')}
+            placeholder="Page # (optional)"
+            className="w-32"
+          />
+          <Button onClick={addNote} disabled={!note}>Save Note</Button>
+        </div>
+      ) : (
+        <p>Log in to view and create personal notes.</p>
+      )}
+      <div className="space-y-2">
+        {notes.map((n) => (
+          <div key={n.id} className="border p-2 rounded-md">
+            <p className="text-sm text-muted-foreground">
+              {n.page_number ? `Page ${n.page_number}: ` : ''}
+              {new Date(n.created_at).toLocaleString()}
+            </p>
+            <p className="mb-2 whitespace-pre-wrap">{n.note}</p>
+            {user && (
+              <Button size="sm" variant="outline" onClick={() => deleteNote(n.id)}>
+                Delete
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/pages/pdfs/[id].tsx
+++ b/pages/pdfs/[id].tsx
@@ -1,0 +1,157 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { useState } from 'react';
+import db from '@/db';
+import { parsePostgresArray } from '@/lib/utils';
+import { Pdf, PdfComment, PdfNote } from '@/types';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { CommentList } from '@/components/PdfComments/CommentList';
+import { NewCommentForm } from '@/components/PdfComments/NewCommentForm';
+import { NotesSection } from '@/components/PdfNotes/NotesSection';
+import { useAuth } from '@/contexts/AuthContext';
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import axios from 'axios';
+
+interface PdfPageProps {
+  pdf: Pdf & { username: string };
+  initialComments: PdfComment[];
+  initialNotes: PdfNote[];
+}
+
+export default function PdfPage({ pdf, initialComments, initialNotes }: PdfPageProps) {
+  const { user } = useAuth();
+  const [comments, setComments] = useState<PdfComment[]>(initialComments);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [ratingCounts, setRatingCounts] = useState({ quality: 0, theology: 0, helpfulness: 0 });
+
+  const handleCommentAdded = (comment: PdfComment) => {
+    setComments((prev) => [comment, ...prev]);
+  };
+
+  const handleVote = async (category: 'quality' | 'theology' | 'helpfulness', value: number) => {
+    try {
+      await axios.post(`/api/pdfs/${pdf.id}/rate`, { category, value });
+      setRatingCounts((prev) => ({ ...prev, [category]: prev[category] + value }));
+    } catch (err) {
+      console.error('Error submitting vote', err);
+    }
+  };
+
+  const nextPage = () => setCurrentPage((p) => p + 1);
+  const prevPage = () => setCurrentPage((p) => Math.max(1, p - 1));
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <Head>
+        <title>{pdf.title}</title>
+      </Head>
+      <div>
+        <h1 className="text-2xl font-bold mb-1">{pdf.title}</h1>
+        {pdf.author && <p className="text-muted-foreground">By {pdf.author}</p>}
+        <div className="flex flex-wrap gap-2 mt-2">
+          {pdf.themes.map((t) => (
+            <Badge key={t}>{t}</Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Button onClick={prevPage} variant="outline">Previous Page</Button>
+          <span>Page {currentPage}</span>
+          <Button onClick={nextPage} variant="outline">Next Page</Button>
+        </div>
+        {/* TODO: Replace iframe with custom PDF.js viewer */}
+        <div className="border rounded-md overflow-hidden h-[70vh]">
+          <iframe
+            src={`${pdf.file_url}#page=${currentPage}`}
+            className="w-full h-full"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Ratings</h2>
+        <div className="space-y-2">
+          {(['quality', 'theology', 'helpfulness'] as const).map((cat) => (
+            <div key={cat} className="flex items-center space-x-2">
+              <span className="capitalize w-32">{cat}</span>
+              <Button aria-label={`Upvote ${cat}`} size="sm" variant="outline" onClick={() => handleVote(cat, 1)}>
+                <ThumbsUp className="h-4 w-4" />
+              </Button>
+              <Button aria-label={`Downvote ${cat}`} size="sm" variant="outline" onClick={() => handleVote(cat, -1)}>
+                <ThumbsDown className="h-4 w-4" />
+              </Button>
+              <span>{ratingCounts[cat]}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <Separator />
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Comments</h2>
+        {user ? (
+          <NewCommentForm pdfId={pdf.id} onCommentAdded={handleCommentAdded} />
+        ) : (
+          <p>Please log in to add a comment.</p>
+        )}
+        <CommentList comments={comments} pdfId={pdf.id} onCommentAdded={handleCommentAdded} />
+      </section>
+
+      <Separator />
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">My Notes</h2>
+        <NotesSection initialNotes={initialNotes} pdfId={pdf.id} />
+      </section>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { id } = context.params as { id: string };
+  try {
+    const pdf = await db('pdfs')
+      .join('users', 'pdfs.uploaded_by', 'users.id')
+      .where('pdfs.id', id)
+      .select('pdfs.*', 'users.username')
+      .first();
+
+    if (!pdf) {
+      return { notFound: true };
+    }
+
+    if (typeof pdf.themes === 'string' || Array.isArray(pdf.themes)) {
+      pdf.themes = parsePostgresArray(pdf.themes);
+    } else {
+      pdf.themes = [];
+    }
+
+    const comments = await db('pdf_comments')
+      .join('users', 'pdf_comments.user_id', 'users.id')
+      .where('pdf_comments.pdf_id', id)
+      .select('pdf_comments.*', 'users.username')
+      .orderBy('pdf_comments.created_at', 'asc');
+
+    const notes = await db('pdf_notes')
+      .where('pdf_id', id)
+      .select();
+
+    return {
+      props: {
+        pdf: JSON.parse(JSON.stringify(pdf)),
+        initialComments: JSON.parse(JSON.stringify(comments)),
+        initialNotes: JSON.parse(JSON.stringify(notes)),
+      },
+    };
+  } catch (error) {
+    console.error('Error fetching PDF:', error);
+    return { notFound: true };
+  }
+};


### PR DESCRIPTION
## Summary
- add `PdfComments` components for displaying and posting comments on a PDF
- add `PdfNotes` component for personal notes on a PDF
- implement dynamic route `pages/pdfs/[id].tsx` with server-side data fetch and PDF viewing controls

## Testing
- `npm run lint`
- `npm run build` *(fails: Collecting build traces)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc90def08320a1e3249225652c56