### PR TITLE
Add PDFs navigation links

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -4,3 +4,6 @@
 - Added PDF upload and reader feature. Users can submit PDF documents with Bible study content which are processed for verse references.
 - Created database tables: `pdfs`, `pdf_comments`, `pdf_notes`, `pdf_ratings`, and `pdf_verses`.
 - PDFs can be commented on, rated, and linked to verses similar to songs.
+
+## 2025-06-04
+- Linked the new PDFs page from the homepage and sidebar navigation.

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { Upload, Map, List, MessageSquare, Headphones, User, HelpCircle, X } from 'lucide-react';
+import { Upload, Map, List, MessageSquare, Headphones, User, HelpCircle, FileText, X } from 'lucide-react';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -12,6 +12,7 @@ const menuItems = [
   { name: 'Playlists', icon: List, href: '/playlists' },
   { name: 'Forum', icon: MessageSquare, href: '/forum' },
   { name: 'Listen', icon: Headphones, href: '/listen' },
+  { name: 'PDFs', icon: FileText, href: '/pdfs' },
   { name: 'Profile', icon: User, href: '/profile' },
   { name: 'How To', icon: HelpCircle, href: '/how-to' },
 ];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,6 +25,7 @@ export default function Home() {
     { title: 'Upload Your Songs', description: 'Share your own Bible-inspired compositions.', icon: Upload, link: '/upload' },
     { title: 'Track Progress', description: 'See which parts of the Bible have been put to music.', icon: Map, link: '/progress' },
     { title: 'Join Discussions', description: 'Engage with the community in our forum.', icon: MessageSquare, link: '/forum' },
+    { title: 'Study PDFs', description: 'Browse uploaded study guides in PDF format.', icon: BookOpen, link: '/pdfs' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- link to PDFs from sidebar
- add Study PDFs card on the homepage
- log the new links in DEVLOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840089e16fc83209fbf0bcf57fa6c29