### PR TITLE
Add PDF dashboard page

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -7,3 +7,6 @@
 
 ## 2025-06-04
 - Linked the new PDFs page from the homepage and sidebar navigation.
+
+## 2025-06-05
+- Created a dashboard at `/pdfs` listing all uploaded PDFs with search and links to individual documents.

--- a/pages/pdfs/index.tsx
+++ b/pages/pdfs/index.tsx
@@ -1,0 +1,94 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useState } from 'react';
+import db from '@/db';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Pdf } from '@/types';
+
+interface PdfWithUser extends Pdf {
+  username: string;
+}
+
+interface PdfDashboardProps {
+  pdfs: PdfWithUser[];
+}
+
+export default function PdfDashboard({ pdfs }: PdfDashboardProps) {
+  const [search, setSearch] = useState('');
+
+  const filtered = pdfs.filter((pdf) => {
+    const term = search.toLowerCase();
+    return (
+      pdf.title.toLowerCase().includes(term) ||
+      (pdf.author && pdf.author.toLowerCase().includes(term)) ||
+      pdf.themes.some((t) => t.toLowerCase().includes(term))
+    );
+  });
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <Head>
+        <title>Study PDFs</title>
+      </Head>
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl font-bold">Study PDFs</h1>
+        <Link href="/pdfs/upload">
+          <Button>Upload New PDF</Button>
+        </Link>
+      </div>
+      <Input
+        placeholder="Search PDFs..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-md"
+      />
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((pdf) => (
+          <Card key={pdf.id}>
+            <CardHeader>
+              <CardTitle>{pdf.title}</CardTitle>
+              {pdf.author && <CardDescription>By {pdf.author}</CardDescription>}
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Uploaded by {pdf.username} on {new Date(pdf.created_at).toLocaleDateString()}
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {pdf.themes.map((t) => (
+                  <Badge key={t}>{t}</Badge>
+                ))}
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Link href={`/pdfs/${pdf.id}`} className="ml-auto">
+                <Button size="sm">View</Button>
+              </Link>
+            </CardFooter>
+          </Card>
+        ))}
+        {filtered.length === 0 && <p>No PDFs found.</p>}
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  try {
+    const pdfs = await db('pdfs')
+      .join('users', 'pdfs.uploaded_by', 'users.id')
+      .select('pdfs.*', 'users.username')
+      .orderBy('pdfs.created_at', 'desc');
+    const parsed = pdfs.map((p) => ({
+      ...p,
+      themes: Array.isArray(p.themes) ? p.themes : typeof p.themes === 'string' ? p.themes.replace(/^{|}$/g, '').split(',').map((t) => t.trim()) : [],
+    }));
+    return { props: { pdfs: JSON.parse(JSON.stringify(parsed)) } };
+  } catch (error) {
+    console.error('Error fetching PDFs:', error);
+    return { props: { pdfs: [] } };
+  }
+};


### PR DESCRIPTION
## Summary
- add a new `/pdfs` page listing uploaded PDFs with search and links
- document this dashboard in `DEVLOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840833fadac8320ae9f6ad0a59c8dad