### PR TITLE
Fix PDF upload form submission

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -13,3 +13,5 @@
 
 ## 2025-06-06
 - Fixed runtime error on the PDF upload page by wrapping the form in `FormProvider` so `PdfUploadProgressBar` can access form context.
+## 2025-06-07
+- Fixed form submission for PDF uploads by inserting the URL into the `file_url` column instead of a nonexistent `pdf_url` field.

--- a/pages/api/pdfs/upload.ts
+++ b/pages/api/pdfs/upload.ts
@@ -94,7 +94,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .insert({
           title,
           author: author || null,
-          pdf_url: fullUrl,
+          file_url: fullUrl,
           ai_assisted: ai_assisted || false,
           themes,
           uploaded_by,


### PR DESCRIPTION
## Summary
- correctly insert PDFs with `file_url` column
- log the fix in `DEVLOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841264b412c832081715a43608c4f1b