### PR TITLE
Fix AWS variable names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Developers should ensure OCR tools are available if PDFs lack embedded text. The
 
 - `AWS_S3_BUCKET_NAME` – S3 bucket where files are stored.
 - `AWS_REGION` – region for S3 operations.
-- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3.
+- `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` – credentials for S3.
 - `CDN_URL` – optional base URL used when serving uploaded files.
 
 - PDF uploads are limited to 10MB. The client requests a presigned URL from `/api/upload-url` with `uploadType: "pdf"` before uploading directly to S3.

--- a/Reference/pdfs_table_reference.md
+++ b/Reference/pdfs_table_reference.md
@@ -30,3 +30,12 @@ Stores metadata for uploaded PDF documents containing scriptural or thematic con
 |------------|---------|------|-------------|
 | pdfs_uploaded_by_idx | uploaded_by | B-tree | For efficient queries on a user's uploads |
 | pdfs_created_at_idx | created_at | B-tree | For sorting or filtering by creation time |
+
+## Environment Configuration
+
+These environment variables control PDF storage in AWS S3:
+
+- `AWS_S3_BUCKET_NAME` – target bucket for PDF uploads.
+- `AWS_REGION` – AWS region of the bucket.
+- `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` – credentials used by the server.
+- `CDN_URL` – optional base URL when serving uploaded PDFs.


### PR DESCRIPTION
## Summary
- document the correct `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` variable names in README
- add AWS environment configuration section to the PDFs table reference

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68427d1a8a608320a06b4084efe177f4