### PR TITLE
Enforce JWT_SECRET environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ To make your next App run smoothly in production make sure to deploy your projec
 
 You can also produce a production build by running `npm run build` and [changing the run command](https://docs.replit.com/programming-ide/configuring-repl#run) to `npm run start`.
 
+## Environment Variables
+
+- `JWT_SECRET` – required for JWT authentication. The build process will fail if this variable is not set.
+
 ## PDF Upload and Reader
 
 Users can upload PDF documents containing scripture or Bible study material. Uploaded files are processed to extract text, detect verse references, and link them to the existing verse database. Each PDF has its own page where readers can navigate pages, leave comments, track personal notes, and rate the document.

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,0 +1,7 @@
+export function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is missing. See README for configuration.')
+  }
+  return secret
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required for JWT authentication.')
+}
+
 const nextConfig = {
   // Configure image optimization and remote patterns
   images: {
@@ -24,7 +28,7 @@ const nextConfig = {
   // Runtime configuration
   env: {
     // Security-related environment variables
-    JWT_SECRET: process.env.JWT_SECRET || 'fallback-secret-for-debugging',
+    JWT_SECRET: process.env.JWT_SECRET,
     
     // AWS configuration
     AWS_REGION: process.env.AWS_REGION,

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import db from '../../../db'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
+import { getJwtSecret } from '@/lib/jwt'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -31,13 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { password_hash, ...userWithoutPassword } = user
     
     // Generate JWT token
-    console.log('JWT_SECRET status:', process.env.JWT_SECRET ? 'Defined' : 'Undefined')
-    if (!process.env.JWT_SECRET) {
-      console.error('JWT_SECRET is not defined')
-      return res.status(500).json({ message: 'Server configuration error: JWT_SECRET is missing' })
-    }
-    
-    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, { expiresIn: '1d' })
+    const token = jwt.sign({ userId: user.id }, getJwtSecret(), { expiresIn: '1d' })
 
     console.log('Login successful, returning user data and token')
     res.status(200).json({ user: userWithoutPassword, token })

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import db from '../../../db'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
+import { getJwtSecret } from '@/lib/jwt'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -19,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }).returning('*')
 
     // Generate JWT token
-    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET!, { expiresIn: '1d' })
+    const token = jwt.sign({ userId: user.id }, getJwtSecret(), { expiresIn: '1d' })
 
     res.status(201).json({ 
       user: { id: user.id, username: user.username, email: user.email },

--- a/pages/api/users/[id]/activities.ts
+++ b/pages/api/users/[id]/activities.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import db from '@/lib/db';
 import jwt from 'jsonwebtoken';
+import { getJwtSecret } from '@/lib/jwt';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -27,7 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     let decoded;
     
     try {
-      decoded = jwt.verify(token, process.env.JWT_SECRET as string) as { userId: number };
+      decoded = jwt.verify(token, getJwtSecret()) as { userId: number };
     } catch (error) {
       console.error('Token verification failed:', error);
       return res.status(401).json({ 

--- a/pages/api/users/[id]/unread-activities-count.ts
+++ b/pages/api/users/[id]/unread-activities-count.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import db from '@/lib/db';
 import jwt from 'jsonwebtoken';
+import { getJwtSecret } from '@/lib/jwt';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -18,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const token = authHeader.split(' ')[1];
     try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as { userId: number };
+      const decoded = jwt.verify(token, getJwtSecret()) as { userId: number };
       if (decoded.userId !== Number(id)) {
         return res.status(403).json({ message: 'Forbidden' });
       }


### PR DESCRIPTION
## Summary
- remove JWT secret fallback in `next.config.js`
- add runtime helper `getJwtSecret` and use in API routes
- document JWT_SECRET requirement in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68427d6d6b588320ba104123b8def6ea