### PR TITLE
Fix shuffle to include all filtered songs

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -15,3 +15,4 @@
 - Fixed runtime error on the PDF upload page by wrapping the form in `FormProvider` so `PdfUploadProgressBar` can access form context.
 ## 2025-06-07
 - Fixed form submission for PDF uploads by inserting the URL into the `file_url` column instead of a nonexistent `pdf_url` field.
+\n## 2025-06-08\n- Updated shuffle mode to load all songs for the current filters so shuffle picks from the full list.

--- a/contexts/MusicPlayerContext.tsx
+++ b/contexts/MusicPlayerContext.tsx
@@ -35,6 +35,7 @@ interface MusicPlayerContextType {
   audioElement: HTMLAudioElement | null;
   isMinimized: boolean;
   setIsMinimized: React.Dispatch<React.SetStateAction<boolean>>;
+  updateQueue: (newQueue: MusicPlayerSong[]) => void;
   // ... additional controls
 }
 
@@ -63,6 +64,16 @@ export const MusicPlayerProvider: React.FC<{ children: React.ReactNode }> = ({ c
       setHasIncrementedPlayCount(true);
     } catch (error) {
       console.error('Error incrementing play count:', error);
+    }
+  };
+
+  const updateQueue = (newQueue: MusicPlayerSong[]) => {
+    setQueue(newQueue);
+    if (currentSong) {
+      const newIndex = newQueue.findIndex((s) => s.id === currentSong.id);
+      if (newIndex !== -1) {
+        setCurrentIndex(newIndex);
+      }
     }
   };
 
@@ -260,6 +271,7 @@ export const MusicPlayerProvider: React.FC<{ children: React.ReactNode }> = ({ c
         isShuffling,
         repeatMode,
         queue,
+        updateQueue,
         audioElement: audioRef.current, // Expose audio element
         isMinimized,
         setIsMinimized,


### PR DESCRIPTION
## Summary
- expose an `updateQueue` helper in `MusicPlayerContext`
- load full song list in `listen` page when shuffle is enabled
- pass `totalSongs` and `fetchAllSongs` to `SongList`
- fetch all songs before shuffling
- document shuffle update in `DEVLOG`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68427e13e73c8320b0d63c0fa194b221