### PR TITLE
Fix Promise.withResolvers error for PDF viewer

### DIFF
--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,0 +1,11 @@
+if (typeof (Promise as any).withResolvers !== 'function') {
+  (Promise as any).withResolvers = function withResolvers() {
+    let resolve: (value?: any) => void;
+    let reject: (reason?: any) => void;
+    const promise = new Promise<any>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve: resolve!, reject: reject! } as any;
+  };
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,4 @@
+import '../lib/polyfills'
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'


### PR DESCRIPTION
## Summary
- polyfill `Promise.withResolvers` for older Node runtimes
- import polyfill in `_app.tsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684289a21cf4832080b10692c3803127