### PR TITLE
Improve shuffle to preload and randomize all songs

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -15,4 +15,9 @@
 - Fixed runtime error on the PDF upload page by wrapping the form in `FormProvider` so `PdfUploadProgressBar` can access form context.
 ## 2025-06-07
 - Fixed form submission for PDF uploads by inserting the URL into the `file_url` column instead of a nonexistent `pdf_url` field.
-\n## 2025-06-08\n- Updated shuffle mode to load all songs for the current filters so shuffle picks from the full list.
+
+## 2025-06-08
+- Updated shuffle mode to load all songs for the current filters so shuffle picks from the full list.
+
+## 2025-06-09
+- Shuffle button now preloads and shuffles every song that matches the current filters when enabled.

--- a/pages/listen.tsx
+++ b/pages/listen.tsx
@@ -152,7 +152,7 @@ function ListenContent({
   const router = useRouter()
   const querySearch = router.query.search as string || ''
   const { user } = useAuth(); // useAuth already provides User | null with correct type
-  const { currentSong, isMinimized, isShuffling, queue, updateQueue } = useMusicPlayer();
+  const { currentSong, isMinimized, isShuffling, queue, updateQueue, registerShuffleLoader } = useMusicPlayer();
   const isSmallScreen = useMediaQuery("(max-width: 768px)");
   const { isOpen: isSidebarOpen } = useSidebar(); // Get sidebar state
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -389,6 +389,7 @@ function ListenContent({
     return result.songs
   }, [debouncedFilters, user, selectedPlaylist, totalSongs])
 
+
   const toPlayerSong = (s: Song) => ({
     id: s.id,
     title: s.title,
@@ -402,6 +403,13 @@ function ListenContent({
     bible_translation_used: s.bible_translation_used,
     uploaded_by: s.uploaded_by,
   })
+
+  useEffect(() => {
+    registerShuffleLoader(async () => {
+      const all = await fetchAllSongs()
+      return all.map(toPlayerSong)
+    })
+  }, [fetchAllSongs, registerShuffleLoader])
 
   useEffect(() => {
     if (isShuffling && queue.length < totalSongs && totalSongs > songs.length) {


### PR DESCRIPTION
## Summary
- implement shuffle loader registration to MusicPlayerContext
- preload all filtered songs and shuffle them when shuffle is enabled
- register loader in Listen page
- document update in DEVLOG

## Testing
- `JWT_SECRET=dummy npm run lint`
- `JWT_SECRET=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68428a4aa57483209fe83fc780987fe4