### PR TITLE
Add PDF comments API

### DIFF
--- a/Reference/pdf_comments_table_reference.md
+++ b/Reference/pdf_comments_table_reference.md
@@ -30,3 +30,7 @@ Stores public comments on PDFs, allowing for discussion and feedback. Supports n
 | pdf_comments_pdf_id_idx | pdf_id | B-tree | Quickly fetch comments for a PDF |
 | pdf_comments_parent_comment_id_idx | parent_comment_id | B-tree | Retrieve replies for a comment |
 | pdf_comments_user_id_idx | user_id | B-tree | Lookup comments by user |
+
+## API Endpoints
+- `GET /api/pdfs/[id]/comments` – list comments for a PDF including commenter info.
+- `POST /api/pdfs/[id]/comments` – create a new comment. Requires `user_id` and `comment`; accepts optional `parent_comment_id`.

--- a/pages/api/pdfs/[id]/comments.ts
+++ b/pages/api/pdfs/[id]/comments.ts
@@ -1,0 +1,60 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import db from '@/db';
+import sanitizeHtml from 'sanitize-html';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req;
+  const pdfId = Number(req.query.id);
+
+  if (method === 'GET') {
+    try {
+      const comments = await db('pdf_comments')
+        .join('users', 'pdf_comments.user_id', 'users.id')
+        .select(
+          'pdf_comments.*',
+          'users.username',
+          'users.profile_image_url'
+        )
+        .where('pdf_comments.pdf_id', pdfId)
+        .orderBy('pdf_comments.created_at', 'asc');
+
+      res.status(200).json(comments);
+    } catch (error) {
+      console.error('Error fetching comments:', error);
+      res.status(500).json({ message: 'Error fetching comments' });
+    }
+  } else if (method === 'POST') {
+    const { comment, parent_comment_id, user_id } = req.body;
+
+    if (!user_id || !comment) {
+      return res.status(400).json({ message: 'Missing required fields' });
+    }
+
+    try {
+      const sanitizedComment = sanitizeHtml(comment, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+        allowedAttributes: { ...sanitizeHtml.defaults.allowedAttributes, '*': ['class'] },
+      });
+
+      const [newComment] = await db('pdf_comments')
+        .insert({
+          pdf_id: pdfId,
+          user_id,
+          comment: sanitizedComment,
+          parent_comment_id: parent_comment_id || null,
+          created_at: new Date(),
+        })
+        .returning('*');
+
+      const user = await db('users').where('id', user_id).first();
+
+      res.status(201).json({ ...newComment, username: user.username });
+    } catch (error) {
+      console.error('Error adding comment:', error);
+      res.status(500).json({ message: 'Error adding comment' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `/api/pdfs/[id]/comments` for listing and posting PDF comments
- sanitize comment input
- document new endpoints in PDF comments reference

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68432512237c832088e8d5c9d1ba0bf9