### PR TITLE
Fix PDF viewer layout, loading and fullscreen

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -26,3 +26,7 @@
 - Replaced the old react-pdf viewer with the Doqment PDF.js viewer.
 - PDFs now open in an iframe at `/pdf-viewer` with smart zoom and the ability to hide the toolbar.
 - The viewer also respects the site's light and dark themes.
+
+## 2025-06-11
+- Fixed cross-origin errors preventing PDFs from loading in the viewer.
+- `/pdf-viewer` now renders without the main layout and includes a fullscreen toggle.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,9 +47,12 @@ const LoadingWrapper = ({ children }) => {
   )
 }
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }: AppProps & { Component: any }) {
   const router = useRouter()
-  const isHomePage = router.pathname === '/'
+  const isBarePage =
+    router.pathname === '/' ||
+    router.pathname === '/pdf-viewer' ||
+    Component.disableLayout
 
   useEffect(() => {
     // Disable the default loading indicator
@@ -75,7 +78,7 @@ function MyApp({ Component, pageProps }: AppProps) {
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
               <TooltipProvider>
                 <LoadingWrapper>
-                  {isHomePage ? (
+                  {isBarePage ? (
                     <Component {...pageProps} />
                   ) : (
                     <Layout>

--- a/pages/pdf-viewer.tsx
+++ b/pages/pdf-viewer.tsx
@@ -1,20 +1,58 @@
 import { useRouter } from 'next/router';
 import Head from 'next/head';
+import { useRef, useState } from 'react';
+import { Maximize, Minimize } from 'lucide-react';
 
-export default function PdfViewerPage() {
+interface PdfViewerPageType extends React.FC {
+  disableLayout?: boolean;
+}
+
+export const PdfViewerPage: PdfViewerPageType = () => {
   const router = useRouter();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
   const { file } = router.query;
   const fileParam = Array.isArray(file) ? file[0] : file;
   const src = fileParam
     ? `/pdfreader/doqment-main/src/pdfjs/web/viewer.html?file=${encodeURIComponent(fileParam)}`
     : '/pdfreader/doqment-main/src/pdfjs/web/viewer.html';
 
+  const toggleFullscreen = () => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    if (!document.fullscreenElement) {
+      iframe.requestFullscreen?.();
+      setIsFullscreen(true);
+    } else {
+      document.exitFullscreen?.();
+      setIsFullscreen(false);
+    }
+  };
+
   return (
     <>
       <Head>
         <title>PDF Viewer</title>
       </Head>
-      <iframe src={src} className="w-full h-screen border-none" />
+      <div className="relative w-full h-screen">
+        <iframe ref={iframeRef} src={src} className="w-full h-full border-none" />
+        <button
+          aria-label="Toggle fullscreen"
+          onClick={toggleFullscreen}
+          className="absolute top-2 right-2 z-10 bg-background/70 border border-border rounded-md p-1"
+        >
+          {isFullscreen ? (
+            <Minimize className="w-5 h-5" />
+          ) : (
+            <Maximize className="w-5 h-5" />
+          )}
+        </button>
+      </div>
     </>
   );
-}
+};
+
+(PdfViewerPage as any).disableLayout = true;
+
+export default PdfViewerPage;

--- a/public/pdfreader/doqment-main/src/pdfjs/web/app.js
+++ b/public/pdfreader/doqment-main/src/pdfjs/web/app.js
@@ -2304,27 +2304,8 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   ]);
   // eslint-disable-next-line no-var
   var validateFileURL = function (file) {
-    if (!file) {
-      return;
-    }
-    const viewerOrigin = URL.parse(window.location)?.origin || "null";
-    if (HOSTED_VIEWER_ORIGINS.has(viewerOrigin)) {
-      // Hosted or local viewer, allow for any file locations
-      return;
-    }
-    const fileOrigin = URL.parse(file, window.location)?.origin;
-    if (fileOrigin === viewerOrigin) {
-      return;
-    }
-    const ex = new Error("file origin does not match viewer's");
-
-    PDFViewerApplication._documentError("pdfjs-loading-error", {
-      message: ex.message,
-    });
-    // Removing of the following line will not guarantee that the viewer will
-    // start accepting URLs from foreign origin -- CORS headers on the remote
-    // server must be properly configured.
-    throw ex;
+    // Allow loading PDFs from any origin.
+    return;
   };
 
   // eslint-disable-next-line no-var


### PR DESCRIPTION
## Summary
- allow loading PDFs from any origin in the bundled pdf.js
- add fullscreen toggle and disable layout for pdf viewer
- skip layout for the `/pdf-viewer` route
- document fix in DEVLOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68469a0451dc8320bfe2b4578160b4bd