### PR TITLE
Fix pdf viewer modules

### DIFF
--- a/public/pdfreader/doqment-main/src/pdfjs/web/viewer-geckoview.html
+++ b/public/pdfreader/doqment-main/src/pdfjs/web/viewer-geckoview.html
@@ -55,9 +55,9 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs-lib": "../src/pdf.js",
           "pdfjs-web/": "./",
 
-          "fluent-bundle": "../node_modules/@fluent/bundle/esm/index.js",
-          "fluent-dom": "../node_modules/@fluent/dom/esm/index.js",
-          "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
+          "fluent-bundle": "https://cdn.jsdelivr.net/npm/@fluent/bundle@0.19.1/esm/index.js",
+          "fluent-dom": "https://cdn.jsdelivr.net/npm/@fluent/dom@0.10.1/esm/index.js",
+          "cached-iterable": "https://cdn.jsdelivr.net/npm/cached-iterable@0.3.0/src/index.mjs",
 
           "display-cmap_reader_factory": "../src/display/cmap_reader_factory.js",
           "display-standard_fontdata_factory": "../src/display/standard_fontdata_factory.js",

--- a/public/pdfreader/doqment-main/src/pdfjs/web/viewer.html
+++ b/public/pdfreader/doqment-main/src/pdfjs/web/viewer.html
@@ -58,9 +58,9 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs-lib": "../src/pdf.js",
           "pdfjs-web/": "./",
 
-          "fluent-bundle": "../node_modules/@fluent/bundle/esm/index.js",
-          "fluent-dom": "../node_modules/@fluent/dom/esm/index.js",
-          "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
+          "fluent-bundle": "https://cdn.jsdelivr.net/npm/@fluent/bundle@0.19.1/esm/index.js",
+          "fluent-dom": "https://cdn.jsdelivr.net/npm/@fluent/dom@0.10.1/esm/index.js",
+          "cached-iterable": "https://cdn.jsdelivr.net/npm/cached-iterable@0.3.0/src/index.mjs",
 
           "display-cmap_reader_factory": "../src/display/cmap_reader_factory.js",
           "display-standard_fontdata_factory": "../src/display/standard_fontdata_factory.js",


### PR DESCRIPTION
## Summary
- update pdf.js viewer import map to CDN modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68469f9289d48320bbd8a3d274d5d18e