### PR TITLE
Lazy-load pdf-parse in PDF upload API

### DIFF
--- a/pages/api/pdfs/upload.ts
+++ b/pages/api/pdfs/upload.ts
@@ -1,6 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import pdfParse from 'pdf-parse';
 import s3Client from '@/lib/s3';
 import db from '@/db';
 import { Knex } from 'knex';
@@ -50,6 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Attempt text extraction
     let extractedText = '';
     try {
+      const pdfParse = (await import('pdf-parse')).default;
       const data = await pdfParse(fileBuffer);
       extractedText = data.text.trim();
     } catch (err) {


### PR DESCRIPTION
## Summary
- lazy-load `pdf-parse` inside `pages/api/pdfs/upload.ts`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847a2fcff0c8320bee8736d328da780