### PR TITLE
Enable fullscreen in pdf viewer

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -30,3 +30,6 @@
 ## 2025-06-11
 - Fixed cross-origin errors preventing PDFs from loading in the viewer.
 - `/pdf-viewer` now renders without the main layout and includes a fullscreen toggle.
+
+## 2025-06-12
+- Added `allow="fullscreen"` to PDF iframes so the viewer can request fullscreen mode.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Database tables and indexes are created using Knex migrations found in `db/migra
 Users can upload PDF documents containing scripture or Bible study material. Uploaded files are processed to extract text, detect verse references, and link them to the existing verse database. Each PDF has its own page where readers can view the document through an integrated PDF.js viewer, leave comments, track personal notes, and rate the document.
 
 The new viewer is powered by **Doqment** which adds smart zoom and allows hiding the toolbar. It also respects the app's light and dark themes so PDFs match the surrounding UI.
+Frames include `allow="fullscreen"` so the viewer can enter fullscreen mode.
 
 Developers should ensure OCR tools are available if PDFs lack embedded text. The default implementation tries `pdf-parse` first and can fall back to Tesseract or AWS Textract. Configure the following environment variables for uploads:
 

--- a/pages/pdf-viewer.tsx
+++ b/pages/pdf-viewer.tsx
@@ -36,7 +36,12 @@ export const PdfViewerPage: PdfViewerPageType = () => {
         <title>PDF Viewer</title>
       </Head>
       <div className="relative w-full h-screen">
-        <iframe ref={iframeRef} src={src} className="w-full h-full border-none" />
+        <iframe
+          ref={iframeRef}
+          src={src}
+          className="w-full h-full border-none"
+          allow="fullscreen"
+        />
         <button
           aria-label="Toggle fullscreen"
           onClick={toggleFullscreen}

--- a/pages/pdfs/[id].tsx
+++ b/pages/pdfs/[id].tsx
@@ -55,7 +55,11 @@ export default function PdfPage({ pdf, initialComments, initialNotes }: PdfPageP
       </div>
 
       <div className="space-y-2">
-        <iframe src={`/pdf-viewer?file=${encodeURIComponent(pdf.file_url)}`} className="w-full h-[70vh] border rounded-md" />
+        <iframe
+          src={`/pdf-viewer?file=${encodeURIComponent(pdf.file_url)}`}
+          className="w-full h-[70vh] border rounded-md"
+          allow="fullscreen"
+        />
       </div>
 
       <Separator />


### PR DESCRIPTION
## Summary
- allow fullscreen mode for the standalone pdf viewer iframe
- add `allow="fullscreen"` for pdf display on pdf detail pages
- document fullscreen viewer support

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847a60f1e488320bf6368429105ef9e