### PR TITLE
Fix PDF viewer fullscreen toggle

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -33,3 +33,6 @@
 
 ## 2025-06-12
 - Added `allow="fullscreen"` to PDF iframes so the viewer can request fullscreen mode.
+
+## 2025-06-13
+- The fullscreen toggle now uses the browser Fullscreen API and shows a toast when entering or exiting fullscreen.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Database tables and indexes are created using Knex migrations found in `db/migra
 Users can upload PDF documents containing scripture or Bible study material. Uploaded files are processed to extract text, detect verse references, and link them to the existing verse database. Each PDF has its own page where readers can view the document through an integrated PDF.js viewer, leave comments, track personal notes, and rate the document.
 
 The new viewer is powered by **Doqment** which adds smart zoom and allows hiding the toolbar. It also respects the app's light and dark themes so PDFs match the surrounding UI.
-Frames include `allow="fullscreen"` so the viewer can enter fullscreen mode.
+Frames include `allow="fullscreen"` so the viewer can enter fullscreen mode. A built-in toggle uses the browser Fullscreen API and displays a toast when entering or exiting fullscreen.
 
 Developers should ensure OCR tools are available if PDFs lack embedded text. The default implementation tries `pdf-parse` first and can fall back to Tesseract or AWS Textract. Configure the following environment variables for uploads:
 

--- a/pages/pdf-viewer.tsx
+++ b/pages/pdf-viewer.tsx
@@ -14,6 +14,15 @@ export const PdfViewerPage: PdfViewerPageType = () => {
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
+    const onChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  useEffect(() => {
     if (isFullscreen) {
       document.body.classList.add('overflow-hidden');
     } else {
@@ -27,9 +36,17 @@ export const PdfViewerPage: PdfViewerPageType = () => {
     ? `/pdfreader/doqment-main/src/pdfjs/web/viewer.html?file=${encodeURIComponent(fileParam)}`
     : '/pdfreader/doqment-main/src/pdfjs/web/viewer.html';
 
-  const toggleFullscreen = () => {
+  const toggleFullscreen = async () => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
     try {
-      setIsFullscreen((prev) => !prev);
+      if (!document.fullscreenElement) {
+        await iframe.requestFullscreen();
+        toast.success('Entered fullscreen');
+      } else {
+        await document.exitFullscreen();
+        toast.success('Exited fullscreen');
+      }
     } catch (error) {
       console.warn('Failed to toggle fullscreen', error);
       toast.error('Failed to toggle fullscreen');


### PR DESCRIPTION
## Summary
- use the Fullscreen API in the pdf viewer
- document fullscreen toggle behaviour in README and DEVLOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847d79641988320b4c7a44dd80f23b1