### PR TITLE
Fix PDF viewer fullscreen

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -36,3 +36,6 @@
 
 ## 2025-06-13
 - The fullscreen toggle now uses the browser Fullscreen API and shows a toast when entering or exiting fullscreen.
+
+## 2025-06-14
+- Fixed PDF viewer fullscreen toggle to work across browsers by requesting fullscreen on the iframe's document and adding `allowFullScreen`.

--- a/pages/pdf-viewer.tsx
+++ b/pages/pdf-viewer.tsx
@@ -41,8 +41,16 @@ export const PdfViewerPage: PdfViewerPageType = () => {
     if (!iframe) return;
     try {
       if (!document.fullscreenElement) {
-        await iframe.requestFullscreen();
-        toast.success('Entered fullscreen');
+        const target =
+          typeof (iframe as any).requestFullscreen === 'function'
+            ? iframe
+            : iframe.contentDocument?.documentElement;
+        if (target && target.requestFullscreen) {
+          await target.requestFullscreen();
+          toast.success('Entered fullscreen');
+        } else {
+          throw new Error('Fullscreen not supported');
+        }
       } else {
         await document.exitFullscreen();
         toast.success('Exited fullscreen');
@@ -70,6 +78,7 @@ export const PdfViewerPage: PdfViewerPageType = () => {
           src={src}
           className="w-full h-full border-none"
           allow="fullscreen"
+          allowFullScreen
         />
         <button
           aria-label="Toggle fullscreen"


### PR DESCRIPTION
## Summary
- update pdf viewer fullscreen logic to request on internal document
- allow fullscreen capability explicitly in iframe
- log the fix in DEVLOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848c237c6b4832082172bd920b9bf4b