### PR TITLE
Fix PDF cover image url on pdf dashboard

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -58,3 +58,7 @@
 - Removed in-app PDF viewer and replaced it with a simple "Open PDF" button.
 - The PDF detail page now highlights the NotebookLM link with an icon and tooltip.
 - Deleted the obsolete `/pdf-viewer` route.
+
+## 2025-06-26
+- Fixed PDF cover images showing a broken URL when `NEXT_PUBLIC_CDN_URL` was unset.
+- The PDF list and detail pages now check if `image_url` already includes a protocol before prefixing the CDN URL.

--- a/pages/pdfs/[id].tsx
+++ b/pages/pdfs/[id].tsx
@@ -75,7 +75,11 @@ export default function PdfPage({ pdf, initialComments, initialNotes }: PdfPageP
         <h1 className="text-2xl font-bold mb-1">{pdf.title}</h1>
         {pdf.image_url && (
           <Image
-            src={`${process.env.NEXT_PUBLIC_CDN_URL}${pdf.image_url}`}
+            src={
+              pdf.image_url.startsWith('http')
+                ? pdf.image_url
+                : `${process.env.NEXT_PUBLIC_CDN_URL ?? ''}${pdf.image_url}`
+            }
             alt={pdf.title}
             width={600}
             height={400}

--- a/pages/pdfs/index.tsx
+++ b/pages/pdfs/index.tsx
@@ -52,7 +52,11 @@ export default function PdfDashboard({ pdfs }: PdfDashboardProps) {
           <Card key={pdf.id}>
             {pdf.image_url && (
               <Image
-                src={`${process.env.NEXT_PUBLIC_CDN_URL}${pdf.image_url}`}
+                src={
+                  pdf.image_url.startsWith('http')
+                    ? pdf.image_url
+                    : `${process.env.NEXT_PUBLIC_CDN_URL ?? ''}${pdf.image_url}`
+                }
                 alt={pdf.title}
                 width={320}
                 height={240}


### PR DESCRIPTION
## Summary
- handle absolute URLs for pdf `image_url`
- document fix in DEVLOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849d95460048320bc2d2f4647031cc6