### PR TITLE
Improve PDF image cropping

### DIFF
--- a/pages/pdfs/[id].tsx
+++ b/pages/pdfs/[id].tsx
@@ -80,8 +80,8 @@ export default function PdfPage({ pdf, initialComments, initialNotes }: PdfPageP
             }
             alt={pdf.title}
             width={600}
-            height={400}
-            className="my-4 w-full max-h-60 object-cover rounded"
+            height={800}
+            className="my-4 w-full max-h-[700px] object-cover rounded"
           />
         )}
         {pdf.author && <p className="text-muted-foreground">By {pdf.author}</p>}

--- a/pages/pdfs/index.tsx
+++ b/pages/pdfs/index.tsx
@@ -59,8 +59,8 @@ export default function PdfDashboard({ pdfs }: PdfDashboardProps) {
                 }
                 alt={pdf.title}
                 width={320}
-                height={240}
-                className="w-full h-40 object-cover rounded-t"
+                height={480}
+                className="w-full h-60 object-cover rounded-t"
               />
             )}
             <CardHeader>

--- a/pages/pdfs/upload.tsx
+++ b/pages/pdfs/upload.tsx
@@ -356,7 +356,14 @@ export default function UploadPdf() {
 
           <Modal isOpen={isCropperOpen} onClose={handleCropCancel}>
             {cropImageUrl && (
-              <ImageCropper imageUrl={cropImageUrl} onCropComplete={handleCropComplete} onCancel={handleCropCancel} maxHeight={300} />
+              <ImageCropper
+                imageUrl={cropImageUrl}
+                onCropComplete={handleCropComplete}
+                onCancel={handleCropCancel}
+                maxHeight={400}
+                aspectRatio={0.75}
+                quality={1}
+              />
             )}
           </Modal>
 


### PR DESCRIPTION
## Summary
- allow specifying aspect ratio and quality in `ImageCropper`
- crop PDF covers with portrait ratio
- show PDF covers in portrait orientation on dashboard and detail page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e11278d08320af7706f9fcfefdbe