### PR TITLE
Improve PDF verse section and listen link filters

### DIFF
--- a/pages/listen.tsx
+++ b/pages/listen.tsx
@@ -160,6 +160,37 @@ function ListenContent({
   const [selectedPlaylist, setSelectedPlaylist] = useState<string | null>(initialSelectedPlaylist)
   const [filterOptions, setFilterOptions] = useState<FilterOptions>(initialFilterOptions)
 
+  // Apply filters from query parameters on initial load
+  useEffect(() => {
+    if (!router.isReady) return;
+    const parseArray = (val: string | string[] | undefined) =>
+      Array.isArray(val) ? val : val ? [val] : [];
+
+    const books = parseArray(router.query.bibleBooks);
+    const chaptersArr = parseArray(router.query.bibleChapters);
+    const verses = parseArray(router.query.bibleVerses);
+
+    const chapterObj: { [book: string]: number[] } = {};
+    chaptersArr.forEach((c) => {
+      const [book, chapter] = c.split(':');
+      const ch = Number(chapter);
+      if (book && !Number.isNaN(ch)) {
+        if (!chapterObj[book]) chapterObj[book] = [];
+        if (!chapterObj[book].includes(ch)) chapterObj[book].push(ch);
+      }
+    });
+
+    if (books.length || chaptersArr.length || verses.length) {
+      setFilterOptions((prev) => ({
+        ...prev,
+        bibleBooks: books.length ? (books as string[]) : prev.bibleBooks,
+        bibleChapters:
+          Object.keys(chapterObj).length > 0 ? chapterObj : prev.bibleChapters,
+        bibleVerses: verses.length ? (verses as string[]) : prev.bibleVerses,
+      }));
+    }
+  }, [router.isReady, router.query.bibleBooks, router.query.bibleChapters, router.query.bibleVerses]);
+
   // Adjust bottom offset for filter button
   const filterButtonBottomClass = useMemo(() => {
     // Adjusted values to ensure both buttons align correctly

--- a/pages/pdfs/[id].tsx
+++ b/pages/pdfs/[id].tsx
@@ -24,6 +24,7 @@ import {
   TooltipContent,
 } from '@/components/ui/tooltip';
 import DOMPurify from 'isomorphic-dompurify';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { BIBLE_BOOKS } from '@/lib/constants';
 
 interface BibleVerse {
@@ -202,23 +203,32 @@ export default function PdfPage({ pdf, bibleVerses, initialComments, initialNote
         ) : verses.length === 0 ? (
           <p>No verses linked.</p>
         ) : (
-          <div className="space-y-4">
-            {verses.map((v, i) => (
-              <div key={i}>
-                <div className="flex items-center gap-2">
-                  <p className="font-semibold">{`${v.book} ${v.chapter}:${v.verse}`}</p>
-                  <Link
-                    href={`/listen?bibleVerses=${encodeURIComponent(`${v.book} ${v.chapter}:${v.verse}`)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Headphones className="w-4 h-4" />
-                  </Link>
+          <ScrollArea className="max-h-[400px] pr-4">
+            <div className="space-y-4">
+              {verses.map((v, i) => (
+                <div key={i}>
+                  <div className="flex items-center gap-2">
+                    <p className="font-semibold">{`${v.book} ${v.chapter}:${v.verse}`}</p>
+                    <Link
+                      href={{
+                        pathname: '/listen',
+                        query: {
+                          bibleBooks: v.book,
+                          bibleChapters: `${v.book}:${v.chapter}`,
+                          bibleVerses: `${v.book} ${v.chapter}:${v.verse}`,
+                        },
+                      }}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Headphones className="w-4 h-4" />
+                    </Link>
+                  </div>
+                  <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(v.text) }} />
                 </div>
-                <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(v.text) }} />
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </ScrollArea>
         )}
       </section>
 


### PR DESCRIPTION
## Summary
- limit PDF verse section height with scrolling
- link to listen page now includes book/chapter/verse filters
- parse filter query params in listen page so incoming links apply filters

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e4f06ef883208595bde3dc7f2f44