### PR TITLE
Fix song shuffle feature and API calls

### DIFF
--- a/SHUFFLE_FIX_IMPLEMENTATION.md
+++ b/SHUFFLE_FIX_IMPLEMENTATION.md
@@ -1,0 +1,61 @@
+# Shuffle Feature Fix Implementation
+
+## Problem Description
+
+The shuffle feature had two main issues:
+
+1. **Incomplete Song Pool**: The shuffle only worked with songs currently loaded in the UI (20-40 songs due to pagination), not all songs matching the current filters/playlist.
+
+2. **Infinite API Calls**: When shuffle was enabled, the API was being called repeatedly every few milliseconds with requests like:
+   ```
+   GET /api/songs?page=1&limit=20&sortBy=mostRecent&sortOrder=desc&limit=112 304 in 111ms
+   ```
+
+## Root Causes
+
+1. **Dependency Loop**: The `useEffect` hooks in `listen.tsx` had circular dependencies that caused them to re-run continuously when shuffle was active.
+
+2. **TotalSongs Dependency**: The `fetchAllSongs` function depended on `totalSongs`, which changed with each API response, triggering re-renders and new API calls.
+
+## Implemented Fixes
+
+### 1. Fixed `fetchAllSongs` Function
+- Removed `totalSongs` from dependencies
+- Now makes two API calls: first to get the total count, then to fetch all songs
+- This prevents the dependency loop caused by `totalSongs` changing
+
+### 2. Used Refs to Avoid Dependency Issues
+- Created refs for `fetchAllSongs`, `toPlayerSong`, and `updateQueue`
+- This prevents the `useEffect` hooks from re-running when these functions are recreated
+
+### 3. Added Debouncing
+- Added a 500ms debounce to the shuffle queue update
+- Prevents rapid successive API calls when filters change
+
+### 4. Improved Effect Logic
+- Combined multiple effects into one
+- Added early return when shuffle is not active
+- Added proper cleanup to cancel pending updates
+
+## How It Works Now
+
+1. **When Shuffle is Enabled**: 
+   - Loads ALL songs matching current filters/playlist (not just visible ones)
+   - Shuffles the complete list
+   - Updates the play queue with all shuffled songs
+
+2. **When Filters/Playlist Change During Shuffle**:
+   - Automatically fetches new songs matching the updated criteria
+   - Re-shuffles and updates the queue
+   - Debounced to prevent excessive API calls
+
+3. **When Shuffle is Disabled**:
+   - Restores the original unshuffled order
+   - Maintains the current playing position
+
+## Benefits
+
+- Users can now shuffle through their entire library or filtered results
+- No more infinite API calls
+- Smooth performance with proper debouncing
+- Dynamic updates when filters change during shuffle


### PR DESCRIPTION
Fixes song shuffle to include all matching songs and eliminates infinite API calls.

The previous implementation caused an infinite loop of API calls and limited the shuffle pool to only visible songs. This was due to `useEffect` dependencies creating a circular reference with `fetchAllSongs` and `totalSongs`, leading to continuous re-fetching. The fix modifies `fetchAllSongs` to fetch all songs correctly, uses refs to stabilize dependencies, and debounces updates to prevent excessive API calls.