### PR TITLE
Fix vote counting query alias usage

### DIFF
--- a/pages/api/songs/index.ts
+++ b/pages/api/songs/index.ts
@@ -107,9 +107,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .leftJoin(
           db('votes')
             .select('song_id')
-            .sum(db.raw(`CASE WHEN vote_type = 'Best Musically' THEN vote_value ELSE 0 END AS best_musically_votes`))
-            .sum(db.raw(`CASE WHEN vote_type = 'Best Lyrically' THEN vote_value ELSE 0 END AS best_lyrically_votes`))
-            .sum(db.raw(`CASE WHEN vote_type = 'Best Overall' THEN vote_value ELSE 0 END AS best_overall_votes`))
+            .select(db.raw(`SUM(CASE WHEN vote_type = 'Best Musically' THEN vote_value ELSE 0 END) AS best_musically_votes`))
+            .select(db.raw(`SUM(CASE WHEN vote_type = 'Best Lyrically' THEN vote_value ELSE 0 END) AS best_lyrically_votes`))
+            .select(db.raw(`SUM(CASE WHEN vote_type = 'Best Overall' THEN vote_value ELSE 0 END) AS best_overall_votes`))
             .groupBy('song_id')
             .as('vote_counts'),
           'songs.id',


### PR DESCRIPTION
Fix vote counting query to correctly use Knex.js `select(db.raw())` for aggregated sums with aliases.

The previous implementation incorrectly passed `db.raw()` expressions with `AS` aliases to Knex's `sum()` method, which expects a column name. This resulted in malformed SQL and syntax errors.