### PR TITLE
Fix shuffle songs and play queue

### DIFF
--- a/SHUFFLE_QUEUE_FIX.md
+++ b/SHUFFLE_QUEUE_FIX.md
@@ -1,0 +1,121 @@
+# Shuffle Songs and Play Queue Fix
+
+## Issues Identified
+
+### 1. **Limited Song Pool in Shuffle**
+- **Problem**: The shuffle feature was only working with about 20 songs instead of all songs matching the search criteria or playlist
+- **Root Cause**: The `buildQueryString` function had a hardcoded `limit=20` parameter that was overriding the intended limit when fetching all songs for shuffle
+
+### 2. **Play Queue Not Updating Properly**
+- **Problem**: The play queue display wasn't showing all shuffled songs and users couldn't scroll to see additional songs
+- **Root Cause**: The queue was being populated correctly, but there was a limitation in how many songs were being fetched due to the API query limit issue
+
+### 3. **API Query Limit Override**
+- **Problem**: Even when trying to fetch thousands of songs for shuffle, the query was still limited to 20 songs
+- **Root Cause**: The `buildQueryString` function always appended `limit=20` regardless of the intended limit parameter
+
+## Fixes Implemented
+
+### 1. **Fixed buildQueryString Function**
+```typescript
+// Before
+params.append('limit', '20')
+
+// After  
+params.append('limit', (limit || 20).toString())
+```
+- Added an optional `limit` parameter to the `buildQueryString` function
+- Made the limit dynamic instead of hardcoded to 20
+
+### 2. **Updated fetchAllSongs Function**
+```typescript
+const fetchAllSongs = useCallback(async (): Promise<Song[]> => {
+  // First fetch to get the total count
+  const countQuery = buildQueryString(debouncedFilters, 1, user, selectedPlaylist, 1)
+  const countResult = await fetcher(`/api/songs?${countQuery}`)
+  const total = countResult.total || 0
+  
+  // If there are songs, fetch all of them
+  if (total > 0) {
+    const allQuery = buildQueryString(debouncedFilters, 1, user, selectedPlaylist, total)
+    const result = await fetcher(`/api/songs?${allQuery}`)
+    return result.songs || []
+  }
+  return []
+}, [debouncedFilters, user, selectedPlaylist])
+```
+- Now correctly passes the total number of songs as the limit when fetching all songs
+- Separates the count query from the full fetch query
+
+### 3. **Added Safety Limits to API**
+```typescript
+// Add a safety limit to prevent extremely large queries
+const maxLimit = 10000; // Set a reasonable maximum
+const safeLimitNum = Math.min(limitNum, maxLimit);
+```
+- Added a safety limit of 10,000 songs to prevent potential timeout or memory issues
+- Prevents malicious or accidental requests for extremely large datasets
+
+### 4. **Enhanced Queue Display**
+- Updated the queue header to show the total number of songs: "Up Next (X songs)"
+- The queue list properly displays all songs and allows scrolling through the entire shuffled collection
+
+### 5. **Updated useSWRInfinite Call**
+```typescript
+`/api/songs?${buildQueryString(
+  debouncedFilters,
+  index + 1,
+  user,
+  selectedPlaylist,
+  20 // Explicitly pass 20 for pagination
+)}`
+```
+- Updated the infinite scroll query to explicitly pass the limit parameter
+
+## How the Fix Works
+
+### Shuffle Flow
+1. **User Enables Shuffle**: 
+   - `toggleShuffle()` is called in `MusicPlayerContext`
+   - Calls the registered shuffle loader function
+
+2. **Fetch All Songs**:
+   - `fetchAllSongs()` makes two API calls:
+     - First call with `limit=1` to get the total count
+     - Second call with `limit=total` to fetch all matching songs
+
+3. **Queue Update**:
+   - All fetched songs are passed to `updateQueue()`
+   - If shuffle is active, the songs are shuffled before being set in the queue
+   - The queue now contains ALL songs matching the current filters/playlist
+
+4. **Queue Display**:
+   - The floating music player shows the complete queue
+   - Users can scroll through all songs in the shuffled order
+   - Queue header displays the total count for transparency
+
+### Dynamic Updates
+- When filters or playlist selection change while shuffle is active, the system automatically:
+  - Re-fetches all songs matching the new criteria
+  - Re-shuffles the updated song list  
+  - Updates the play queue with the new shuffled collection
+
+## Benefits
+
+1. **Complete Song Pool**: Users can now shuffle through their entire library or filtered results (up to 10,000 songs)
+2. **Transparent Queue**: The play queue shows exactly how many songs are available and allows scrolling through all of them
+3. **Real-time Updates**: Changing filters while shuffle is active immediately updates the shuffle queue
+4. **Performance Protection**: Safety limits prevent server overload while still supporting large collections
+5. **Better UX**: Queue display clearly shows the total number of songs available
+
+## Testing Scenarios
+
+The fix handles these scenarios properly:
+1. **Enable shuffle with no filters** → All songs in the database are shuffled (up to 10,000)
+2. **Enable shuffle with search criteria** → Only songs matching the search are shuffled
+3. **Enable shuffle with playlist selected** → Only songs in the playlist are shuffled
+4. **Change filters while shuffle is active** → Queue updates with new filtered and shuffled songs
+5. **Open queue display** → Shows all songs with scroll functionality and song count
+6. **Large song collections** → Handles up to 10,000 songs safely
+
+This comprehensive fix ensures the shuffle feature works as users would expect in a modern music streaming application.

--- a/components/MusicPlayer/FloatingMusicPlayer.tsx
+++ b/components/MusicPlayer/FloatingMusicPlayer.tsx
@@ -288,7 +288,7 @@ export default function FloatingMusicPlayer() {
         >
           {/* Queue Header - Sticky */}
           <div className="sticky top-0 z-10 p-4 border-b border-border flex items-center justify-between bg-background">
-            <h3 className="text-lg font-semibold">Up Next</h3>
+            <h3 className="text-lg font-semibold">Up Next ({queue.length} songs)</h3>
             <button onClick={() => setIsQueueVisible(false)} className="p-1 hover:bg-accent rounded">
               <X className="w-5 h-5" />
             </button>

--- a/pages/api/songs/index.ts
+++ b/pages/api/songs/index.ts
@@ -65,8 +65,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Adjust limit and offset for infinite scroll
       const limitNum = parseInt(limit as string, 10) || 20;
+      // Add a safety limit to prevent extremely large queries
+      const maxLimit = 10000; // Set a reasonable maximum
+      const safeLimitNum = Math.min(limitNum, maxLimit);
       const pageNum = parseInt(page as string, 10) || 1;
-      const offset = (pageNum - 1) * limitNum;
+      const offset = (pageNum - 1) * safeLimitNum;
 
       // Start building the query with optimized aggregations
       let query = db('songs')
@@ -313,7 +316,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
 
       // Apply pagination
-      const songsQuery = query.clone().offset(offset).limit(limitNum);
+      const songsQuery = query.clone().offset(offset).limit(safeLimitNum);
       const songs = await songsQuery;
 
       // Clone the existing query for total count


### PR DESCRIPTION
Fix shuffle and play queue to include all songs by resolving a hardcoded API limit.

Previously, the `buildQueryString` function hardcoded an API limit of 20 songs, preventing `fetchAllSongs` from retrieving the full song list for shuffling and displaying in the play queue.