### PR TITLE
Fix filter page positioning on progress.tsx

### DIFF
--- a/components/ProgressPage/Filters.tsx
+++ b/components/ProgressPage/Filters.tsx
@@ -106,12 +106,12 @@ export function Filters({ filterOptions, setFilterOptions, setIsFilterExpanded }
             </Button>
           </PopoverTrigger>
           <PopoverContent 
-            className="w-[calc(100vw-2rem)] max-w-[300px] p-0 bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl border border-white/30 dark:border-slate-700/30 rounded-xl" 
+            className="w-80 max-w-[calc(100vw-2rem)] p-0 bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl border border-white/30 dark:border-slate-700/30 rounded-xl" 
             side="bottom" 
             align="center"
             sideOffset={4}
             avoidCollisions={true}
-            collisionPadding={16}
+            collisionPadding={8}
           >
             <div className="p-3">
               {lyricsAdherenceOptions.map((option) => (
@@ -171,13 +171,13 @@ function FilterSelect({ title, value, onChange, options }: FilterSelectProps) {
         <SelectValue placeholder={title} />
       </SelectTrigger>
       <SelectContent 
-        className="w-[calc(100vw-2rem)] max-w-[300px] bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl border border-white/30 dark:border-slate-700/30 rounded-xl"
+        className="w-80 max-w-[calc(100vw-2rem)] bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl border border-white/30 dark:border-slate-700/30 rounded-xl"
         position="popper"
         side="bottom"
         align="center"
         sideOffset={4}
         avoidCollisions={true}
-        collisionPadding={16}
+        collisionPadding={8}
       >
         <SelectGroup>
           <SelectLabel className="text-emerald-600 dark:text-emerald-400 font-semibold">{title}</SelectLabel>

--- a/pages/progress.tsx
+++ b/pages/progress.tsx
@@ -348,7 +348,7 @@ export default function Progress() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.3 }}
-              className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+              className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-start justify-center pt-20 px-4"
               onClick={() => setIsFilterExpanded(false)}
             >
               <motion.div
@@ -356,7 +356,7 @@ export default function Progress() {
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.95, y: 20 }}
                 transition={{ duration: 0.3 }}
-                className="absolute top-20 left-1/2 transform -translate-x-1/2 w-full max-w-4xl mx-auto px-4"
+                className="w-full max-w-4xl mx-auto"
                 onClick={(e) => e.stopPropagation()}
               >
                 <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl border border-white/30 dark:border-slate-700/30 p-4 sm:p-6 shadow-2xl">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct filter modal and dropdown positioning on the progress page to prevent off-screen display over the hero section.