### PR TITLE
Fix tab selector display issue

### DIFF
--- a/pages/playlists.tsx
+++ b/pages/playlists.tsx
@@ -197,7 +197,7 @@ export default function PlaylistsPage() {
               className="bg-white/70 dark:bg-slate-800/70 backdrop-blur-2xl border border-white/20 dark:border-slate-700/50 rounded-3xl shadow-2xl p-8 md:p-10"
             >
               <Tabs defaultValue="auto" className="w-full">
-                <TabsList className="grid w-full grid-cols-2 lg:grid-cols-4 mb-10 p-1.5 bg-white/60 dark:bg-slate-700/60 backdrop-blur-xl border border-white/20 dark:border-slate-600/50 rounded-2xl shadow-xl h-16">
+                <TabsList className="grid w-full grid-cols-2 lg:grid-cols-4 mb-10 p-1.5 bg-white/60 dark:bg-slate-700/60 backdrop-blur-xl border border-white/20 dark:border-slate-600/50 rounded-2xl shadow-xl min-h-16 auto-rows-fr gap-1.5">
                   {playlistGroups.map((group) => (
                     <TabsTrigger 
                       key={group.tabValue} 


### PR DESCRIPTION
Adjust tab selector layout on `playlist.tsx` to prevent tabs from being cut off on mobile.

The `TabsList` had a fixed height (`h-16`) which, combined with `grid-cols-2` on mobile, caused the bottom row of tabs to be hidden. This PR replaces `h-16` with `min-h-16`, adds `auto-rows-fr` for proper row sizing, and `gap-1.5` for spacing, ensuring all tabs are visible.